### PR TITLE
Fix lead command phase count in README

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "cadence",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Issue-driven, multi-agent development workflow with git worktrees, structured phases, and specialist delegation"
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `claude plugin update cadence@claude-cadence` to update, then restart Claude
 
 | Command | Purpose |
 |---------|---------|
-| `/lead` | Coordinate implementation through 7 structured phases |
+| `/lead` | Coordinate implementation through 8 structured phases (0–7) |
 | `/refine` or `/refine 123` | Refine issues to quality standards |
 
 ### Skills (model-invoked)


### PR DESCRIPTION
## Summary
- Fix `/lead` command description: "7 structured phases" → "8 structured phases (0–7)" to match actual workflow (phases 0 through 7)
- Bump plugin version to 0.0.3

Fixes #1

## Test plan
- [x] Verified all commands, skills, and agents in README match current SKILL.md files
- [x] Verified workflow phase descriptions match `/lead` implementation
- [x] No other stale or outdated information found