### PR TITLE
Add deferred findings convention to lead and review agents

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -80,6 +80,23 @@ Organize feedback by priority:
 
 Be specific: reference file paths and line numbers.
 
+## Deferred Findings
+
+Not every finding needs to block the current PR. For non-blocking findings (typically Suggestions and some Warnings), recommend a tracking plan:
+
+- **Fix now** — Critical findings and Warnings that are cheap to fix in the current PR
+- **Defer** — Findings that are out of scope or would require significant rework. For each deferred finding:
+  1. Recommend whether it fits an existing issue/phase or needs a new issue
+  2. Reference the current PR: "Discovered in #[PR-NUMBER] review"
+  3. Clearly label it as deferred in your review output so the lead can triage
+
+Example in review output:
+```
+**Deferred**:
+- Missing input validation on `parseConfig()` → fits #10 (API hardening phase), discovered in #14 review
+- Unused error codes enum → new issue recommended, discovered in #14 review
+```
+
 ## Posting Reviews
 
 **IMPORTANT:** Do NOT use GitHub's approval system (`gh pr review --approve` or `--request-changes`). All review feedback and approval status must be posted as comments.

--- a/agents/performance-engineer.md
+++ b/agents/performance-engineer.md
@@ -69,6 +69,23 @@ Before analyzing, read `CLAUDE.md` for:
 - Pagination for large datasets
 - Resource pooling
 
+## Deferred Findings
+
+Not every finding needs to block the current PR. For non-blocking findings (typically Low impact), recommend a tracking plan:
+
+- **Fix now** — High impact findings and Medium findings that are cheap to fix
+- **Defer** — Findings that are out of scope or would require significant rework. For each deferred finding:
+  1. Recommend whether it fits an existing issue/phase or needs a new issue
+  2. Reference the current PR: "Discovered in #[PR-NUMBER] review"
+  3. Clearly label it as deferred in your review output so the lead can triage
+
+Example in review output:
+```
+**Deferred**:
+- N+1 query in `fetchUsers()` → fits #10 (query optimization phase), discovered in #14 review
+- Bundle includes unused locale data → new issue recommended, discovered in #14 review
+```
+
 ## Output Format
 
 **Findings**:

--- a/agents/security-engineer.md
+++ b/agents/security-engineer.md
@@ -77,6 +77,23 @@ Before reviewing, read `CLAUDE.md` for:
 | Medium | 4.0-6.9 | Warn, require acknowledgment |
 | Low/Info | 0.1-3.9 | Log, document |
 
+## Deferred Findings
+
+Not every finding needs to block the current PR. For non-blocking findings (typically Medium/Low/Info severity), recommend a tracking plan:
+
+- **Fix now** — Critical and High severity findings, plus Medium findings that are cheap to fix
+- **Defer** — Findings that are out of scope or would require significant rework. For each deferred finding:
+  1. Recommend whether it fits an existing issue/phase or needs a new issue
+  2. Reference the current PR: "Discovered in #[PR-NUMBER] review"
+  3. Clearly label it as deferred in your review output so the lead can triage
+
+Example in review output:
+```
+**Deferred**:
+- Dependency X has a known Low-severity CVE → fits #10 (dependency update phase), discovered in #14 review
+- Missing rate limiting on endpoint Y → new issue recommended, discovered in #14 review
+```
+
 ## Vulnerability Response
 
 1. **Identify severity** using CVSS score

--- a/commands/lead/SKILL.md
+++ b/commands/lead/SKILL.md
@@ -134,7 +134,18 @@ Use `/create-pr` to create the pull request. Link to the issue with `Fixes #[NUM
 2. Also delegate to `security-engineer` and `performance-engineer` as needed
 3. Triage findings by severity (Critical/Warning block merge, Suggestions don't)
 4. Fix-review loop: assign fixes, push, re-review (max 3 cycles before escalation)
-5. Handle deferred findings: create tracking issues for deferred suggestions
+5. Handle deferred findings using the convention below
+
+#### Deferred Findings Convention
+
+When a reviewer marks a finding as deferred (not blocking the current PR), decide where to track it:
+
+- **Add to an existing issue** when the finding naturally fits within a planned phase's scope (e.g., a missing validation that belongs in the API hardening ticket). Add it as a new acceptance criterion on that issue.
+- **Create a new issue** when the finding is independent work that doesn't fit any existing ticket. Label it `agent-discovered`.
+
+In both cases:
+- Link back to the originating review: include "Discovered in #[PR-NUMBER] review" in the finding description
+- Review agents should recommend a target (existing ticket or new issue) in their review output — the lead makes the final call
 
 ### Phase 6: Manual QA (for visual changes)
 


### PR DESCRIPTION
## Summary
- Expands Phase 5 (Code Review Gate) in the lead workflow with a clear convention for when to add deferred findings to existing issues vs. creating new ones
- Adds a "Deferred Findings" section to code-reviewer, security-engineer, and performance-engineer agents instructing them to recommend a target phase/ticket and link back to the originating PR
- Includes example output format so agents produce consistent deferred finding entries

Fixes #23

## Test plan
- [ ] Review the updated lead workflow Phase 5 section for clarity
- [ ] Review each agent's new "Deferred Findings" section for consistency
- [ ] Verify examples reference the correct linking format

🤖 Generated with [Claude Code](https://claude.com/claude-code)