### PR TITLE
Remove 'Present plan' confirmation gate from lead Phase 1

### DIFF
--- a/commands/lead/SKILL.md
+++ b/commands/lead/SKILL.md
@@ -92,7 +92,6 @@ Delegate to specialist agents using the Agent tool. Available agents are listed 
    - Bug fix → Phase 1b (Reproduction)
    - Other → Delegate to appropriate specialist
 4. **Task breakdown**: Create 3-6 discrete units with clear owners
-5. **Post plan to issue** and proceed to implementation
 
 ### Phase 1a: Design Review (for visual changes, if designer agent available)
 


### PR DESCRIPTION
## Summary
- Removes step 5 ("Post plan to issue and proceed to implementation") from Phase 1 in the lead workflow
- Phase 1a (design review) and Phase 6 (manual QA) approval gates remain unchanged

Fixes #28

## Test plan
- [x] Verify step 5 is removed from Phase 1
- [x] Verify Phase 1a approval gate is unchanged
- [x] Verify Phase 6 approval gate is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)