### PR TITLE
Protect worktree cleanup against concurrent agent sessions

### DIFF
--- a/skills/project-ops/scripts/cleanup-merged-worktrees.sh
+++ b/skills/project-ops/scripts/cleanup-merged-worktrees.sh
@@ -49,6 +49,12 @@ for dir in "$WORKTREES_DIR"/*/; do
 
   echo "Cleaning up worktree '$branch_name' (PR #$merged_pr merged)..."
 
+  # Re-check active worktrees immediately before destructive steps to narrow TOCTOU window
+  if git worktree list --porcelain 2>/dev/null | grep -q "^branch refs/heads/$branch_name$"; then
+    echo "Skipping '$branch_name' — became active since scan started"
+    continue
+  fi
+
   # Delete remote branch (may already be deleted by PR merge)
   git push origin --delete "$branch_name" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Replace `git branch --show-current` (CWD-only) with `git worktree list --porcelain` to detect all branches checked out across active worktrees
- Skip any worktree whose branch is checked out anywhere, with a clear skip message

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)