### PR TITLE
Remove createUser mutation from public schema

### DIFF
--- a/services/issues/src/schema/resolvers/ticket.ts
+++ b/services/issues/src/schema/resolvers/ticket.ts
@@ -254,21 +254,6 @@ export const ticketResolvers = {
       });
     },
 
-    createUser: async (
-      _: unknown,
-      { githubId, login, displayName, avatarUrl }: {
-        githubId: number;
-        login: string;
-        displayName: string;
-        avatarUrl?: string;
-      },
-      { prisma }: Context
-    ) => {
-      return prisma.user.create({
-        data: { githubId, login, displayName, avatarUrl: avatarUrl ?? null },
-      });
-    },
-
     transitionTicket: async (
       _: unknown,
       { id, to }: { id: string; to: string },

--- a/services/issues/src/schema/typeDefs/ticket.ts
+++ b/services/issues/src/schema/typeDefs/ticket.ts
@@ -115,7 +115,6 @@ export const ticketTypeDefs = `
     removeLabel(ticketId: ID!, labelId: ID!): Ticket!
     assignTicket(ticketId: ID!, userId: ID!): Ticket!
     unassignTicket(ticketId: ID!): Ticket!
-    createUser(githubId: Int!, login: String!, displayName: String!, avatarUrl: String): User!
     transitionTicket(id: ID!, to: TicketState!): Ticket!
     addBlockRelation(blockerId: ID!, blockedId: ID!): Ticket!
     removeBlockRelation(blockerId: ID!, blockedId: ID!): Ticket!


### PR DESCRIPTION
## Summary
- Removes the `createUser` mutation from the GraphQL schema and resolver
- Users are created exclusively through OAuth/PAT authentication flows via `upsertUser` in `auth.ts`
- The standalone mutation had no auth guard and allowed creating arbitrary users, bypassing the controlled authentication path

## Test plan
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] All 37 tests pass (`vitest run`)
- [x] Verified no other code references `createUser`

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)