### PR TITLE
Use self-hosted GitHub runners for CI workflows

### DIFF
--- a/.github/workflows/agent-service-ci.yml
+++ b/.github/workflows/agent-service-ci.yml
@@ -15,16 +15,13 @@ permissions:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
           go-version-file: services/agents/go.mod
-
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
 
       - name: Run go vet
         working-directory: services/agents
@@ -40,7 +37,7 @@ jobs:
 
   build:
     needs: lint-and-test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/issues-service-ci.yml
+++ b/.github/workflows/issues-service-ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test-service:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     defaults:
       run:
         working-directory: services/issues
@@ -32,7 +32,7 @@ jobs:
       - run: npm run build
 
   test-cli:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: test-service
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         run: cd services/issues-cli && npm ci && npm run typecheck && npm test
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: [test-service, test-cli]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Switch all 5 CI jobs across both workflows from `ubuntu-latest` to `[self-hosted, Linux, X64]`
- Remove `apt-get install tmux` step from agent-service-ci (pre-installed on self-hosted runners)

Fixes #78

## Test plan

- [ ] Verify agent-service-ci runs successfully on self-hosted runner
- [ ] Verify issues-service-ci runs successfully on self-hosted runner
- [ ] Confirm Docker is available on self-hosted runner for the docker build job

🤖 Generated with [Claude Code](https://claude.com/claude-code)