### PR TITLE
Use self-hosted GitHub runners for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     outputs:
       issues-service: ${{ steps.filter.outputs.issues-service }}
       agent-service: ${{ steps.filter.outputs.agent-service }}
@@ -34,7 +34,7 @@ jobs:
   issues-service-test:
     needs: changes
     if: needs.changes.outputs.issues-service == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     defaults:
       run:
         working-directory: services/issues
@@ -54,7 +54,7 @@ jobs:
   issues-cli-test:
     needs: [changes, issues-service-test]
     if: needs.changes.outputs.issues-service == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -72,7 +72,7 @@ jobs:
   issues-service-docker:
     needs: [changes, issues-service-test, issues-cli-test]
     if: needs.changes.outputs.issues-service == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker image
@@ -81,14 +81,12 @@ jobs:
   agent-service-test:
     needs: changes
     if: needs.changes.outputs.agent-service == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: services/agents/go.mod
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
       - name: Run go vet
         working-directory: services/agents
         run: go vet ./...
@@ -102,7 +100,7 @@ jobs:
   agent-service-build:
     needs: [changes, agent-service-test]
     if: needs.changes.outputs.agent-service == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -121,7 +119,7 @@ jobs:
       - issues-service-docker
       - agent-service-test
       - agent-service-build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Check CI status
         env:


### PR DESCRIPTION
## Summary

- Switch all 7 CI jobs in the unified `ci.yml` from `ubuntu-latest` to `[self-hosted, Linux, X64]`
- Remove `apt-get install tmux` step from agent-service-test (pre-installed on self-hosted runners)

Fixes #78

## Test plan

- [ ] Verify ci-status check passes on the PR
- [ ] Confirm Docker is available on self-hosted runner for the docker build job

🤖 Generated with [Claude Code](https://claude.com/claude-code)