### PR TITLE
Fix systemd user unit docker.service dependency

### DIFF
--- a/services/issues/install.sh
+++ b/services/issues/install.sh
@@ -135,8 +135,8 @@ systemd_install() {
   cat > "$unit" <<EOF
 [Unit]
 Description=Claude Cadence Issues Service
-After=docker.service
-Requires=docker.service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Summary
- `install.sh` creates a systemd **user** unit that declares `Requires=docker.service` / `After=docker.service`
- User-scoped units can't reference system-scoped services, causing `Unit docker.service not found` on start
- Replace with `Wants=network-online.target` / `After=network-online.target` — Docker is already running as a system service

## Test plan
- [ ] Run `install.sh install` on Linux with Docker as a system service
- [ ] Verify `systemctl --user start com.claude-cadence.issues` succeeds
- [ ] Verify container comes up after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)