### PR TITLE
fix(#664): hide Cadence wordmark on mobile — logo only

### DIFF
--- a/services/issues-ui/src/styles/layout.module.css
+++ b/services/issues-ui/src/styles/layout.module.css
@@ -40,6 +40,12 @@
   line-height: 1;
 }
 
+@media (max-width: 768px) {
+  .logoText {
+    display: none;
+  }
+}
+
 .navLink {
   margin-left: 0.75rem;
   margin-top: 3px;


### PR DESCRIPTION
## Summary
- Add `@media (max-width: 768px)` rule to `.logoText` in `layout.module.css` to hide the "Cadence" wordmark on mobile screens
- The logo icon remains visible on all screen sizes
- Breakpoint matches the 768px convention used across `board.module.css`, `filter.module.css`, and other layout files

Fixes #664

## Test plan
- [x] Verification checks pass (shellcheck)
- [x] Pure display CSS change — no behavior, state, or interactions; exempt from interaction-level test requirement per `services/issues-ui/CLAUDE.md`
- [ ] Manual QA: verify logo-only on mobile (≤768px), full branding on desktop