### PR TITLE
ci(dokipen-claude-cadence): add HOL ai-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,38 @@
+name: Codex Plugin Scanner CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Plugin Scanner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Run scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@e83708a91ae4812872aa2905b99ad559a55c74ab
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical


### PR DESCRIPTION
I opened this to add a scanner-only check for the Codex plugin surface in the repo.

A couple of repo-specific details I checked first:
- Issue-driven, multi-agent development workflow with git worktrees, structured phases, and specialist delegation
- An issue-driven, multi-agent development workflow plugin for Claude Code
- This repo also includes a thin Codex compatibility layer that reuses the existing Claude prompts, scripts, and CLAUDE.md as the source of truth. See docs/codex-compatibility.md

The current local scan came back 57/100 (grade F).

First-pass findings worth tightening:
- MEDIUM: GitHub Action is not pinned to an immutable commit SHA
- MEDIUM: GitHub Action is not pinned to an immutable commit SHA
- MEDIUM: GitHub Action is not pinned to an immutable commit SHA

This PR only adds the scanner workflow. It does not touch runtime code or release behavior.
If you would rather wire it in a different workflow file, I can adjust the branch.