### PR TITLE
feat(#665): support CADENCE_* env vars for per-machine ticket provider config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ go vet ./... && go test ./...
 
 The agents and scripts will use this command automatically.
 
+### Per-Machine Ticket Provider Overrides
+
+To override ticket provider settings on a specific machine without modifying tracked files, set `CADENCE_*` env vars in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "CADENCE_PROVIDER": "issues-api",
+    "CADENCE_API_URL": "https://cadence.example.com",
+    "CADENCE_PROJECT_ID": "my-project"
+  }
+}
+```
+
+These take precedence over `CLAUDE.md` and apply across all worktrees and clones on the machine. Any combination of the three vars can be set — only the fields you specify are overridden. `CADENCE_API_URL` is also the canonical replacement for the legacy `ISSUES_API_URL` env var (both are supported for backwards compatibility).
+
 ## Adding Project-Specific Agents
 
 Add domain-specific agents to your project's `.claude/agents/` directory. They layer on top of the plugin's core agents:

--- a/commands/lead/SKILL.md
+++ b/commands/lead/SKILL.md
@@ -69,9 +69,9 @@ PROJECT=$(echo "$PROVIDER_CONFIG" | jq -r '.project')
 
 If `PROVIDER` is `github` (or unset), use `gh issue` commands. If `issues-api`, use `issues` CLI commands. **PR operations always use `gh` CLI regardless of provider.**
 
-To target a QA or local `issues-api` instance without modifying `CLAUDE.md`, prefix the invocation with `ISSUES_API_URL`:
+To target a QA or local `issues-api` instance without modifying `CLAUDE.md`, prefix the invocation with `CADENCE_API_URL` (or the legacy `ISSUES_API_URL`):
 ```bash
-ISSUES_API_URL=http://192.168.1.100:5173/graphql /lead 123
+CADENCE_API_URL=http://192.168.1.100:5173/graphql /lead 123
 ```
 This overrides the `api_url` configured in `CLAUDE.md`. Has no effect when provider is `github`.
 

--- a/skills/ticket-provider/SKILL.md
+++ b/skills/ticket-provider/SKILL.md
@@ -131,8 +131,11 @@ The two providers use different terminology in some areas:
 - When using `issues-api`, `project_id` is required for `ticket list`, `ticket create`, and `ticket view` (when using ticket numbers). Other commands take a CUID ticket ID and don't need `--project`.
 - **Issues API identifier two-step**: The display number (`#42`) can only be used with lookup operations (`ticket view N --project $PROJECT` or `mcp__issues__ticket_get` with `number`). Mutation operations — update, transition, label add/remove, comment — require the CUID from the response. Always call `ticket view` (or `mcp__issues__ticket_get`) first to obtain the CUID, then pass it to subsequent mutations.
 - The `issues` CLI must be installed and authenticated (`gh auth token | issues auth login --pat -`)
-- **QA/local override** (`issues-api` only): Set `ISSUES_API_URL` to target a local or QA instance without modifying `CLAUDE.md`. This takes precedence over the `api_url` in `CLAUDE.md`. Has no effect when provider is `github`.
+- **Per-machine configuration**: Set `CADENCE_PROVIDER`, `CADENCE_API_URL`, and/or `CADENCE_PROJECT_ID` env vars to override the corresponding `CLAUDE.md` values without modifying tracked files. These take precedence over `CLAUDE.md` and work across all worktrees and clones on the machine. Configure them once in `~/.claude/settings.json` (see `README.md` for details).
+- **QA/local override** (`issues-api` only): Set `CADENCE_API_URL` (or the legacy `ISSUES_API_URL`) to target a local or QA instance without modifying `CLAUDE.md`. `CADENCE_API_URL` takes precedence over `ISSUES_API_URL` if both are set. Has no effect when provider is `github`.
   ```bash
+  CADENCE_API_URL=http://192.168.1.100:5173/graphql /lead 123
+  # Legacy alias also supported:
   ISSUES_API_URL=http://192.168.1.100:5173/graphql /lead 123
   ```
 

--- a/skills/ticket-provider/scripts/detect-provider.sh
+++ b/skills/ticket-provider/scripts/detect-provider.sh
@@ -39,8 +39,11 @@ PROVIDER=$(printf '%s' "$_parsed" | cut -f1)
 PROJECT=$(printf '%s' "$_parsed"  | cut -f2)
 API_URL=$(printf '%s' "$_parsed"  | cut -f3)
 PROVIDER="${PROVIDER:-github}"
-# Env var takes precedence over CLAUDE.md value
-API_URL="${ISSUES_API_URL:-$API_URL}"
+# CADENCE_* env vars take precedence over CLAUDE.md values
+PROVIDER="${CADENCE_PROVIDER:-$PROVIDER}"
+PROJECT="${CADENCE_PROJECT_ID:-$PROJECT}"
+# CADENCE_API_URL takes precedence over ISSUES_API_URL, which takes precedence over CLAUDE.md
+API_URL="${CADENCE_API_URL:-${ISSUES_API_URL:-$API_URL}}"
 
 jq -n \
   --arg provider "$PROVIDER" \


### PR DESCRIPTION
## Summary
- `detect-provider.sh` now reads `CADENCE_PROVIDER`, `CADENCE_PROJECT_ID`, and `CADENCE_API_URL` env vars, each overriding the corresponding `CLAUDE.md` field
- `CADENCE_API_URL` takes precedence over the legacy `ISSUES_API_URL` (both remain supported for backward compatibility)
- `README.md` gains a "Per-Machine Ticket Provider Overrides" subsection documenting the `~/.claude/settings.json` env block pattern
- `skills/ticket-provider/SKILL.md` override note updated to reference `CADENCE_*` vars alongside `ISSUES_API_URL`

Fixes #665

## Test plan
- [x] Shellcheck passes
- [x] Smoke-tested all three env var overrides and precedence (`CADENCE_API_URL` > `ISSUES_API_URL` > `CLAUDE.md`)
- [x] Unset vars fall back to `CLAUDE.md` values unchanged