### PR TITLE
revert(#667): remove CADENCE_* machine-global ticket provider env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,22 +105,6 @@ go vet ./... && go test ./...
 
 The agents and scripts will use this command automatically.
 
-### Per-Machine Ticket Provider Overrides
-
-To override ticket provider settings on a specific machine without modifying tracked files, set `CADENCE_*` env vars in `~/.claude/settings.json`:
-
-```json
-{
-  "env": {
-    "CADENCE_PROVIDER": "issues-api",
-    "CADENCE_API_URL": "https://cadence.example.com",
-    "CADENCE_PROJECT_ID": "my-project"
-  }
-}
-```
-
-These take precedence over `CLAUDE.md` and apply across all worktrees and clones on the machine. Any combination of the three vars can be set — only the fields you specify are overridden. `CADENCE_API_URL` is also the canonical replacement for the legacy `ISSUES_API_URL` env var (both are supported for backwards compatibility).
-
 ## Adding Project-Specific Agents
 
 Add domain-specific agents to your project's `.claude/agents/` directory. They layer on top of the plugin's core agents:

--- a/commands/lead/SKILL.md
+++ b/commands/lead/SKILL.md
@@ -69,9 +69,9 @@ PROJECT=$(echo "$PROVIDER_CONFIG" | jq -r '.project')
 
 If `PROVIDER` is `github` (or unset), use `gh issue` commands. If `issues-api`, use `issues` CLI commands. **PR operations always use `gh` CLI regardless of provider.**
 
-To target a QA or local `issues-api` instance without modifying `CLAUDE.md`, prefix the invocation with `CADENCE_API_URL` (or the legacy `ISSUES_API_URL`):
+To target a QA or local `issues-api` instance without modifying `CLAUDE.md`, prefix the invocation with `ISSUES_API_URL`:
 ```bash
-CADENCE_API_URL=http://192.168.1.100:5173/graphql /lead 123
+ISSUES_API_URL=http://192.168.1.100:5173/graphql /lead 123
 ```
 This overrides the `api_url` configured in `CLAUDE.md`. Has no effect when provider is `github`.
 

--- a/skills/ticket-provider/SKILL.md
+++ b/skills/ticket-provider/SKILL.md
@@ -131,11 +131,8 @@ The two providers use different terminology in some areas:
 - When using `issues-api`, `project_id` is required for `ticket list`, `ticket create`, and `ticket view` (when using ticket numbers). Other commands take a CUID ticket ID and don't need `--project`.
 - **Issues API identifier two-step**: The display number (`#42`) can only be used with lookup operations (`ticket view N --project $PROJECT` or `mcp__issues__ticket_get` with `number`). Mutation operations — update, transition, label add/remove, comment — require the CUID from the response. Always call `ticket view` (or `mcp__issues__ticket_get`) first to obtain the CUID, then pass it to subsequent mutations.
 - The `issues` CLI must be installed and authenticated (`gh auth token | issues auth login --pat -`)
-- **Per-machine configuration**: Set `CADENCE_PROVIDER`, `CADENCE_API_URL`, and/or `CADENCE_PROJECT_ID` env vars to override the corresponding `CLAUDE.md` values without modifying tracked files. These take precedence over `CLAUDE.md` and work across all worktrees and clones on the machine. Configure them once in `~/.claude/settings.json` (see `README.md` for details).
-- **QA/local override** (`issues-api` only): Set `CADENCE_API_URL` (or the legacy `ISSUES_API_URL`) to target a local or QA instance without modifying `CLAUDE.md`. `CADENCE_API_URL` takes precedence over `ISSUES_API_URL` if both are set. Has no effect when provider is `github`.
+- **QA/local override** (`issues-api` only): Set `ISSUES_API_URL` to target a local or QA instance without modifying `CLAUDE.md`. This takes precedence over the `api_url` in `CLAUDE.md`. Has no effect when provider is `github`.
   ```bash
-  CADENCE_API_URL=http://192.168.1.100:5173/graphql /lead 123
-  # Legacy alias also supported:
   ISSUES_API_URL=http://192.168.1.100:5173/graphql /lead 123
   ```
 

--- a/skills/ticket-provider/scripts/detect-provider.sh
+++ b/skills/ticket-provider/scripts/detect-provider.sh
@@ -39,11 +39,8 @@ PROVIDER=$(printf '%s' "$_parsed" | cut -f1)
 PROJECT=$(printf '%s' "$_parsed"  | cut -f2)
 API_URL=$(printf '%s' "$_parsed"  | cut -f3)
 PROVIDER="${PROVIDER:-github}"
-# CADENCE_* env vars take precedence over CLAUDE.md values
-PROVIDER="${CADENCE_PROVIDER:-$PROVIDER}"
-PROJECT="${CADENCE_PROJECT_ID:-$PROJECT}"
-# CADENCE_API_URL takes precedence over ISSUES_API_URL, which takes precedence over CLAUDE.md
-API_URL="${CADENCE_API_URL:-${ISSUES_API_URL:-$API_URL}}"
+# Env var takes precedence over CLAUDE.md value
+API_URL="${ISSUES_API_URL:-$API_URL}"
 
 jq -n \
   --arg provider "$PROVIDER" \


### PR DESCRIPTION
## Summary
- Reverts b703928 (PR #774) in full
- Removes `CADENCE_PROVIDER`, `CADENCE_PROJECT_ID`, and `CADENCE_API_URL` env var support from `detect-provider.sh`
- Removes "Per-Machine Ticket Provider Overrides" section from `README.md`
- Restores `commands/lead/SKILL.md` and `skills/ticket-provider/SKILL.md` to pre-#665 state
- `ISSUES_API_URL` (QA/local api_url override) preserved unchanged

The machine-global env var approach was wrong — `CADENCE_PROJECT_ID` in `~/.claude/settings.json` would apply to all repos on the machine, not just the intended one. A per-repo solution using `~/.claude/cadence.json` will be tracked separately.

Fixes #667

## Test plan
- [x] Verification checks pass
- [x] `detect-provider.sh` no longer references `CADENCE_*` vars
- [x] `ISSUES_API_URL` still honored