### PR TITLE
feat(#665): per-repo ticket provider overrides via ~/.claude/cadence.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ go vet ./... && go test ./...
 
 The agents and scripts will use this command automatically.
 
+### Per-Repo Ticket Provider Overrides
+
+To override `provider` or `project_id` for a specific repo on your machine — without modifying tracked files — add an entry to `~/.claude/cadence.json`:
+
+```json
+{
+  "repos": {
+    "owner/repo": {
+      "provider": "issues-api",
+      "project_id": "my-project"
+    }
+  }
+}
+```
+
+The key is the `owner/repo` slug (e.g. `dokipen/claude-cadence`), derived from `git remote get-url origin`. Values here take precedence over `CLAUDE.md` and apply across all clones and worktrees of that repo on the machine. `api_url` is not overridable this way — it belongs in `CLAUDE.md`. Use `ISSUES_API_URL` for QA/local `api_url` overrides.
+
 ## Adding Project-Specific Agents
 
 Add domain-specific agents to your project's `.claude/agents/` directory. They layer on top of the plugin's core agents:

--- a/skills/ticket-provider/SKILL.md
+++ b/skills/ticket-provider/SKILL.md
@@ -131,6 +131,7 @@ The two providers use different terminology in some areas:
 - When using `issues-api`, `project_id` is required for `ticket list`, `ticket create`, and `ticket view` (when using ticket numbers). Other commands take a CUID ticket ID and don't need `--project`.
 - **Issues API identifier two-step**: The display number (`#42`) can only be used with lookup operations (`ticket view N --project $PROJECT` or `mcp__issues__ticket_get` with `number`). Mutation operations — update, transition, label add/remove, comment — require the CUID from the response. Always call `ticket view` (or `mcp__issues__ticket_get`) first to obtain the CUID, then pass it to subsequent mutations.
 - The `issues` CLI must be installed and authenticated (`gh auth token | issues auth login --pat -`)
+- **Per-repo machine-local overrides**: Set `provider` and/or `project_id` for a specific repo in `~/.claude/cadence.json` (keyed by `owner/repo`). Values there take precedence over `CLAUDE.md` and apply across all clones and worktrees of that repo on the machine. See `README.md` for the file format.
 - **QA/local override** (`issues-api` only): Set `ISSUES_API_URL` to target a local or QA instance without modifying `CLAUDE.md`. This takes precedence over the `api_url` in `CLAUDE.md`. Has no effect when provider is `github`.
   ```bash
   ISSUES_API_URL=http://192.168.1.100:5173/graphql /lead 123

--- a/skills/ticket-provider/scripts/detect-provider.sh
+++ b/skills/ticket-provider/scripts/detect-provider.sh
@@ -4,6 +4,11 @@
 # Reads the ## Ticket Provider section from CLAUDE.md and outputs the
 # configuration as JSON for programmatic consumption.
 #
+# Per-repo overrides can be set in ~/.claude/cadence.json (keyed by
+# owner/repo derived from git remote origin). Only provider and project_id
+# are overridable this way — api_url belongs in CLAUDE.md.
+# ISSUES_API_URL env var overrides api_url for QA/local testing.
+#
 # Usage:
 #   PROVIDER_CONFIG=$(bash skills/ticket-provider/scripts/detect-provider.sh)
 #   PROVIDER=$(echo "$PROVIDER_CONFIG" | jq -r '.provider')
@@ -39,7 +44,24 @@ PROVIDER=$(printf '%s' "$_parsed" | cut -f1)
 PROJECT=$(printf '%s' "$_parsed"  | cut -f2)
 API_URL=$(printf '%s' "$_parsed"  | cut -f3)
 PROVIDER="${PROVIDER:-github}"
-# Env var takes precedence over CLAUDE.md value
+
+# Per-repo overrides from ~/.claude/cadence.json.
+# Derive owner/repo slug from git remote origin (handles HTTPS and SSH formats).
+_cadence_cfg="${HOME}/.claude/cadence.json"
+if [ -f "$_cadence_cfg" ]; then
+  _remote=$(git remote get-url origin 2>/dev/null || true)
+  # Normalize: strip scheme/host prefix and .git suffix to get owner/repo
+  _slug=$(printf '%s' "$_remote" \
+    | sed 's|^https://[^/]*/||; s|^git@[^:]*:||; s|\.git$||')
+  if [ -n "$_slug" ]; then
+    _override_provider=$(jq -r --arg r "$_slug" '.repos[$r].provider // empty' "$_cadence_cfg" 2>/dev/null || true)
+    _override_project=$(jq -r --arg r "$_slug" '.repos[$r].project_id // empty' "$_cadence_cfg" 2>/dev/null || true)
+    [ -n "$_override_provider" ] && PROVIDER="$_override_provider"
+    [ -n "$_override_project" ] && PROJECT="$_override_project"
+  fi
+fi
+
+# ISSUES_API_URL env var overrides api_url for QA/local testing
 API_URL="${ISSUES_API_URL:-$API_URL}"
 
 jq -n \


### PR DESCRIPTION
## Summary
- `detect-provider.sh` reads `~/.claude/cadence.json` keyed by `owner/repo` (normalized from `git remote get-url origin`, handles both HTTPS and SSH formats)
- Matching `provider` and/or `project_id` entries override `CLAUDE.md` values
- `api_url` is intentionally not overridable this way — it belongs in `CLAUDE.md`; `ISSUES_API_URL` remains the QA/local override
- `README.md` documents the `~/.claude/cadence.json` format
- `skills/ticket-provider/SKILL.md` updated with a per-repo override note

Fixes #665

## Test plan
- [x] shellcheck passes
- [x] No `~/.claude/cadence.json` → behavior identical to before
- [x] Matching entry overrides `provider` and `project_id` independently
- [x] Non-matching repo slug → falls back to `CLAUDE.md`
- [x] HTTPS and SSH remote URL formats both normalize correctly