### PR TITLE
feat(#669): show close button on IN_PROGRESS ticket cards

### DIFF
--- a/services/issues-ui/src/components/TicketCard.test.tsx
+++ b/services/issues-ui/src/components/TicketCard.test.tsx
@@ -446,6 +446,13 @@ describe("TicketCard close button", () => {
     expect(getByTestId("confirm-dialog")).toBeTruthy();
   });
 
+  it("does not show close button for IN_PROGRESS tickets with an active session", () => {
+    const ticket = makeTicket({ state: "IN_PROGRESS", number: 5 });
+    const sessions = [makeSession("lead-5", "running")];
+    const { queryByTestId } = render(<TicketCard ticket={ticket} sessions={sessions} />);
+    expect(queryByTestId("card-close-button")).toBeNull();
+  });
+
   it("does not show close button for CLOSED tickets", () => {
     const ticket = makeTicket({ state: "CLOSED" });
     const { queryByTestId } = render(<TicketCard ticket={ticket} sessions={[]} />);

--- a/services/issues-ui/src/components/TicketCard.test.tsx
+++ b/services/issues-ui/src/components/TicketCard.test.tsx
@@ -430,10 +430,20 @@ describe("TicketCard close button", () => {
     expect(getByTestId("card-close-button")).toBeTruthy();
   });
 
-  it("does not show close button for IN_PROGRESS tickets", () => {
+  it("shows close button for IN_PROGRESS tickets", () => {
     const ticket = makeTicket({ state: "IN_PROGRESS" });
-    const { queryByTestId } = render(<TicketCard ticket={ticket} sessions={[]} />);
-    expect(queryByTestId("card-close-button")).toBeNull();
+    const { getByTestId } = render(<TicketCard ticket={ticket} sessions={[]} />);
+    expect(getByTestId("card-close-button")).toBeTruthy();
+  });
+
+  it("clicking close button on IN_PROGRESS ticket opens confirm dialog", () => {
+    const ticket = makeTicket({ state: "IN_PROGRESS" });
+    const { getByTestId, queryByTestId } = render(
+      <TicketCard ticket={ticket} sessions={[]} />,
+    );
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    fireEvent.click(getByTestId("card-close-button"));
+    expect(getByTestId("confirm-dialog")).toBeTruthy();
   });
 
   it("does not show close button for CLOSED tickets", () => {

--- a/services/issues-ui/src/components/TicketCard.tsx
+++ b/services/issues-ui/src/components/TicketCard.tsx
@@ -61,9 +61,9 @@ export function TicketCard({
   const { optimisticSetDestroying, optimisticResetState } = useSessionsContext();
 
   const launchButtonLabel = getLaunchConfig(ticket.state).buttonLabel;
-  const canClose = ticket.state === "BACKLOG" || ticket.state === "REFINED" || ticket.state === "IN_PROGRESS";
-
   const activeSession = hasActiveSession(sessions ?? [], ticket.number, projectId);
+  const canClose = ticket.state === "BACKLOG" || ticket.state === "REFINED" ||
+    (ticket.state === "IN_PROGRESS" && !activeSession);
 
   const handleActiveSessionClick = useCallback(
     (e: React.MouseEvent) => {

--- a/services/issues-ui/src/components/TicketCard.tsx
+++ b/services/issues-ui/src/components/TicketCard.tsx
@@ -61,7 +61,7 @@ export function TicketCard({
   const { optimisticSetDestroying, optimisticResetState } = useSessionsContext();
 
   const launchButtonLabel = getLaunchConfig(ticket.state).buttonLabel;
-  const canClose = ticket.state === "BACKLOG" || ticket.state === "REFINED";
+  const canClose = ticket.state === "BACKLOG" || ticket.state === "REFINED" || ticket.state === "IN_PROGRESS";
 
   const activeSession = hasActiveSession(sessions ?? [], ticket.number, projectId);
 


### PR DESCRIPTION
## Summary

Extends `canClose` in `TicketCard.tsx` to include `IN_PROGRESS` state, so users can transition a ticket directly from IN_PROGRESS to CLOSED via the card's close button — without having to navigate to the ticket detail view.

Fixes #669

## Test plan

- Updated existing test "does not show close button for IN_PROGRESS tickets" → "shows close button for IN_PROGRESS tickets"
- Added interaction test: clicking the close button on an IN_PROGRESS card opens the confirm dialog
- All 775 unit tests pass (`npm run test`)

## UI Tests (issues-ui changes only)

- [x] New/modified components and hooks have co-located interaction-level tests (see `services/issues-ui/CLAUDE.md`)

## Attack Surface / Invariants

N/A — UI-only change that exposes an existing state transition (IN_PROGRESS → CLOSED) already supported by the GraphQL mutation and backend.