### PR TITLE
feat(#670): mobile dialog for terminal text input

### DIFF
--- a/services/issues-ui/src/components/MobileSessionView.test.tsx
+++ b/services/issues-ui/src/components/MobileSessionView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, fireEvent, act, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
 import { forwardRef, useImperativeHandle } from "react";
 import { create } from "@bufbuild/protobuf";
 import { SessionSchema } from "../gen/hub/v1/hub_pb";
@@ -27,9 +27,16 @@ vi.mock("../styles/agents.module.css", () => ({
     mobileHeader: "mobileHeader",
     mobileSessionContent: "mobileSessionContent",
     mobileBackButton: "mobileBackButton",
+    mobileTypeButton: "mobileTypeButton",
     mobileEnterButton: "mobileEnterButton",
     mobileEscButton: "mobileEscButton",
     mobileCloseButton: "mobileCloseButton",
+    mobileInputDialog: "mobileInputDialog",
+    mobileInputDialogContent: "mobileInputDialogContent",
+    mobileInputTextarea: "mobileInputTextarea",
+    mobileInputDialogActions: "mobileInputDialogActions",
+    mobileInputCancelButton: "mobileInputCancelButton",
+    mobileInputSubmitButton: "mobileInputSubmitButton",
   },
 }));
 
@@ -63,19 +70,31 @@ const makeWindow = (id: string, agentName: string): TiledWindow => ({
   }),
 });
 
+beforeEach(() => {
+  // jsdom does not implement showModal/close on HTMLDialogElement
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute("open", "");
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute("open");
+  });
+});
+
 afterEach(() => {
   mockSendInput.mockReset();
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("MobileSessionView", () => {
-  it("renders back button, enter button, esc button, close button, and terminal", () => {
+  it("renders back button, type button, enter button, esc button, close button, and terminal", () => {
     const win = makeWindow("sess-1", "test-agent");
     const { getByRole, getByTestId } = render(
       <MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />,
     );
 
     expect(getByRole("button", { name: /back to agent list/i })).not.toBeNull();
+    expect(getByRole("button", { name: /open text input dialog/i })).not.toBeNull();
     expect(getByRole("button", { name: /send enter/i })).not.toBeNull();
     expect(getByRole("button", { name: /send escape/i })).not.toBeNull();
     expect(getByRole("button", { name: /close session/i })).not.toBeNull();
@@ -145,6 +164,137 @@ describe("MobileSessionView", () => {
     });
 
     expect(mockSendInput).toHaveBeenCalledWith("\x1b");
+  });
+
+  describe("text input dialog", () => {
+    it("opens the dialog when the Type button is clicked", async () => {
+      const win = makeWindow("sess-d1", "test-agent");
+      render(<MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open text input dialog/i }));
+      });
+
+      expect(screen.getByTestId("mobile-input-textarea")).not.toBeNull();
+    });
+
+    it("sends text + carriage return to terminal on submit", async () => {
+      const win = makeWindow("sess-d2", "test-agent");
+      render(<MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open text input dialog/i }));
+      });
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("mobile-input-textarea"), {
+          target: { value: "hello world" },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("mobile-input-submit"));
+      });
+
+      expect(mockSendInput).toHaveBeenCalledWith("hello world\r");
+    });
+
+    it("dismisses the dialog after submit", async () => {
+      const win = makeWindow("sess-d3", "test-agent");
+      render(<MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open text input dialog/i }));
+      });
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("mobile-input-textarea"), {
+          target: { value: "hello" },
+        });
+        fireEvent.click(screen.getByTestId("mobile-input-submit"));
+      });
+
+      expect(screen.queryByTestId("mobile-input-textarea")).toBeNull();
+    });
+
+    it("dismisses the dialog on cancel without sending input", async () => {
+      const win = makeWindow("sess-d4", "test-agent");
+      render(<MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open text input dialog/i }));
+      });
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("mobile-input-textarea"), {
+          target: { value: "draft text" },
+        });
+        fireEvent.click(screen.getByTestId("mobile-input-cancel"));
+      });
+
+      expect(mockSendInput).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("mobile-input-textarea")).toBeNull();
+    });
+
+    it("sends text on Enter keydown (without Shift)", async () => {
+      const win = makeWindow("sess-d5", "test-agent");
+      render(<MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open text input dialog/i }));
+      });
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("mobile-input-textarea"), {
+          target: { value: "hello" },
+        });
+        fireEvent.keyDown(screen.getByTestId("mobile-input-textarea"), {
+          key: "Enter",
+          shiftKey: false,
+        });
+      });
+
+      expect(mockSendInput).toHaveBeenCalledWith("hello\r");
+    });
+
+    it("does not submit on Shift+Enter (allows newline insertion)", async () => {
+      const win = makeWindow("sess-d6", "test-agent");
+      render(<MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open text input dialog/i }));
+      });
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("mobile-input-textarea"), {
+          target: { value: "line1" },
+        });
+        fireEvent.keyDown(screen.getByTestId("mobile-input-textarea"), {
+          key: "Enter",
+          shiftKey: true,
+        });
+      });
+
+      expect(mockSendInput).not.toHaveBeenCalled();
+      expect(screen.getByTestId("mobile-input-textarea")).not.toBeNull();
+    });
+
+    it("dismisses the dialog on backdrop click", async () => {
+      const win = makeWindow("sess-d7", "test-agent");
+      render(<MobileSessionView win={win} onBack={vi.fn()} onClose={vi.fn()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /open text input dialog/i }));
+      });
+
+      const dialog = screen.getByTestId("mobile-input-dialog");
+      await act(async () => {
+        fireEvent.click(dialog);
+      });
+
+      expect(mockSendInput).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("mobile-input-textarea")).toBeNull();
+    });
   });
 
   describe("visualViewport height tracking", () => {

--- a/services/issues-ui/src/components/MobileSessionView.tsx
+++ b/services/issues-ui/src/components/MobileSessionView.tsx
@@ -35,6 +35,10 @@ function MobileInputDialog({ open, onSubmit, onClose }: MobileInputDialogProps) 
     };
   }, [open]);
 
+  useEffect(() => {
+    if (!open) setText("");
+  }, [open]);
+
   const handleSubmit = useCallback(() => {
     onSubmit(text);
     setText("");
@@ -140,6 +144,13 @@ export function MobileSessionView({ win, onBack, onClose }: MobileSessionViewPro
     };
   }, []);
 
+  const handleDialogSubmit = useCallback((text: string) => {
+    terminalRef.current?.sendInput(text + "\r");
+    setDialogOpen(false);
+  }, []);
+
+  const handleDialogClose = useCallback(() => setDialogOpen(false), []);
+
   return (
     <div
       className={styles.mobileSessionView}
@@ -188,11 +199,8 @@ export function MobileSessionView({ win, onBack, onClose }: MobileSessionViewPro
       </div>
       <MobileInputDialog
         open={dialogOpen}
-        onSubmit={(text) => {
-          terminalRef.current?.sendInput(text + "\r");
-          setDialogOpen(false);
-        }}
-        onClose={() => setDialogOpen(false)}
+        onSubmit={handleDialogSubmit}
+        onClose={handleDialogClose}
       />
     </div>
   );

--- a/services/issues-ui/src/components/MobileSessionView.tsx
+++ b/services/issues-ui/src/components/MobileSessionView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { Terminal } from "./Terminal";
 import type { TerminalHandle } from "./Terminal";
 import type { TiledWindow } from "./TilingLayout";
@@ -10,8 +10,105 @@ interface MobileSessionViewProps {
   onClose: () => void;
 }
 
+interface MobileInputDialogProps {
+  open: boolean;
+  onSubmit: (text: string) => void;
+  onClose: () => void;
+}
+
+function MobileInputDialog({ open, onSubmit, onClose }: MobileInputDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+    if (open && !el.open) {
+      el.showModal();
+      textareaRef.current?.focus();
+    } else if (!open && el.open) {
+      el.close();
+    }
+    return () => {
+      if (el.open) el.close();
+    };
+  }, [open]);
+
+  const handleSubmit = useCallback(() => {
+    onSubmit(text);
+    setText("");
+  }, [text, onSubmit]);
+
+  const handleCancel = useCallback(() => {
+    setText("");
+    onClose();
+  }, [onClose]);
+
+  const handleDialogClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) {
+        handleCancel();
+      }
+    },
+    [handleCancel],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={styles.mobileInputDialog}
+      onClick={handleDialogClick}
+      onCancel={handleCancel}
+      data-testid="mobile-input-dialog"
+    >
+      {open && (
+        <div className={styles.mobileInputDialogContent}>
+          <textarea
+            ref={textareaRef}
+            className={styles.mobileInputTextarea}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a message..."
+            rows={3}
+            data-testid="mobile-input-textarea"
+          />
+          <div className={styles.mobileInputDialogActions}>
+            <button
+              className={styles.mobileInputCancelButton}
+              onClick={handleCancel}
+              data-testid="mobile-input-cancel"
+            >
+              Cancel
+            </button>
+            <button
+              className={styles.mobileInputSubmitButton}
+              onClick={handleSubmit}
+              data-testid="mobile-input-submit"
+            >
+              Send
+            </button>
+          </div>
+        </div>
+      )}
+    </dialog>
+  );
+}
+
 export function MobileSessionView({ win, onBack, onClose }: MobileSessionViewProps) {
   const terminalRef = useRef<TerminalHandle>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const [viewportHeight, setViewportHeight] = useState<number>(
     () => window.visualViewport?.height ?? window.innerHeight,
   );
@@ -58,6 +155,13 @@ export function MobileSessionView({ win, onBack, onClose }: MobileSessionViewPro
           ← Back
         </button>
         <button
+          className={styles.mobileTypeButton}
+          onClick={() => setDialogOpen(true)}
+          aria-label="Open text input dialog"
+        >
+          Type…
+        </button>
+        <button
           className={styles.mobileEnterButton}
           onClick={() => terminalRef.current?.sendInput("\r")}
           aria-label="Send Enter"
@@ -82,6 +186,14 @@ export function MobileSessionView({ win, onBack, onClose }: MobileSessionViewPro
       <div className={styles.mobileSessionContent}>
         <Terminal ref={terminalRef} agentName={win.agentName} sessionId={win.session.id} />
       </div>
+      <MobileInputDialog
+        open={dialogOpen}
+        onSubmit={(text) => {
+          terminalRef.current?.sendInput(text + "\r");
+          setDialogOpen(false);
+        }}
+        onClose={() => setDialogOpen(false)}
+      />
     </div>
   );
 }

--- a/services/issues-ui/src/styles/agents.module.css
+++ b/services/issues-ui/src/styles/agents.module.css
@@ -825,6 +825,7 @@
 }
 
 .mobileBackButton,
+.mobileTypeButton,
 .mobileEnterButton,
 .mobileEscButton,
 .mobileCloseButton {
@@ -842,6 +843,7 @@
   flex: 1;
 }
 
+.mobileTypeButton,
 .mobileEnterButton,
 .mobileEscButton,
 .mobileCloseButton {
@@ -854,11 +856,92 @@
 
 @media (hover: hover) {
   .mobileBackButton:hover,
+  .mobileTypeButton:hover,
   .mobileEnterButton:hover,
   .mobileEscButton:hover,
   .mobileCloseButton:hover {
     background: rgba(128, 128, 128, 0.08);
   }
+}
+
+/* Mobile text input dialog */
+.mobileInputDialog {
+  border: none;
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--text);
+  padding: 0;
+  width: 90vw;
+  max-width: 480px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  margin: auto;
+}
+
+.mobileInputDialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.mobileInputDialogContent {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mobileInputTextarea {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 1rem;
+  font-family: inherit;
+  resize: none;
+  width: 100%;
+  box-sizing: border-box;
+  line-height: 1.4;
+}
+
+.mobileInputTextarea:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.mobileInputDialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.mobileInputCancelButton {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 0.9rem;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.mobileInputCancelButton:hover {
+  background: rgba(128, 128, 128, 0.08);
+}
+
+.mobileInputSubmitButton {
+  background: var(--primary);
+  border: 1px solid var(--primary);
+  color: var(--on-primary);
+  font-size: 0.9rem;
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.mobileInputSubmitButton:hover {
+  background: var(--primary-light);
+  border-color: var(--primary-light);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

Adds a "Type…" button to the `MobileSessionView` header. Tapping it opens a native `<dialog>` modal with a textarea, allowing users to compose text comfortably above the on-screen keyboard. Submitting sends the text to the terminal (appended with `\r`). Shift+Enter inserts a newline; Enter alone submits. Cancel and backdrop-click dismiss without sending.

Desktop/non-mobile viewports are unaffected — `MobileSessionView` is rendered only on mobile.

Closes #670

## Test plan

- [x] `npm run test` in `services/issues-ui` — all 783 tests pass
- [x] New tests cover: open dialog, submit text, dismiss after submit, cancel without sending, Enter key submit, Shift+Enter no-op, backdrop-click dismiss

## UI Tests (issues-ui changes only)

- [x] New/modified components and hooks have co-located interaction-level tests (see `services/issues-ui/CLAUDE.md`)

## Attack Surface / Invariants

N/A — UI-only change. No new API endpoints, auth boundaries, or external inputs. Text entered in the dialog is forwarded to the existing `sendInput` terminal handle, which has no change in trust boundary.