### PR TITLE
feat(#671): close window panel when session is killed from sidebar

### DIFF
--- a/services/issues-ui/src/components/AgentManager.test.tsx
+++ b/services/issues-ui/src/components/AgentManager.test.tsx
@@ -886,6 +886,33 @@ describe("per-project window state — #564", () => {
     expect(tilingArea.textContent).toContain("No sessions for");
   });
 
+  it("killing a session from the sidebar closes its open window panel", async () => {
+    const agentName = "test-agent";
+    const sessionId = "sess-kill-1";
+    const sessions = [makeSession(sessionId, agentName)];
+    const key = `${agentName}:${sessionId}`;
+
+    const { getAllByTestId, queryByTestId } = render(
+      <MemoryRouter><AgentManager sessions={sessions} sessionsLoaded={true} selectedProject={null} /></MemoryRouter>,
+    );
+
+    // Open the window by clicking the session in the sidebar
+    await act(async () => {
+      fireEvent.click(getAllByTestId("sidebar-session")[0]);
+    });
+    expect(capturedWindows.map((w) => w.key)).toContain(key);
+    expect(queryByTestId("tiling-layout")).toBeTruthy();
+
+    // Kill the session from the sidebar
+    mockDeleteSession.mockResolvedValueOnce(undefined);
+    await act(async () => {
+      fireEvent.click(getAllByTestId("sidebar-session-kill")[0]);
+    });
+
+    // Window should be removed from the tiling layout
+    expect(capturedWindows.map((w) => w.key)).not.toContain(key);
+  });
+
   // selectedProject → null: switching from a project to no project restores global state
   it("restores global window state when switching from a project to no project", async () => {
     const repoA = "https://github.com/owner/repo-a";

--- a/services/issues-ui/src/components/AgentManager.tsx
+++ b/services/issues-ui/src/components/AgentManager.tsx
@@ -345,6 +345,7 @@ export function AgentManager({ sessions, sessionsLoaded, selectedProject }: Agen
           openKeys={openKeys}
           minimizedKeys={minimizedKeys}
           onSessionClick={handleSessionClick}
+          onKill={handleTerminated}
           isCollapsed={isCollapsed}
           onToggle={toggleSidebar}
         />

--- a/services/issues-ui/src/components/SessionList.test.tsx
+++ b/services/issues-ui/src/components/SessionList.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, fireEvent, cleanup } from "@testing-library/react";
+import { render, fireEvent, cleanup, act } from "@testing-library/react";
 import { create } from "@bufbuild/protobuf";
 import { AgentSchema, SessionSchema } from "../gen/hub/v1/hub_pb";
 import { SessionList } from "./SessionList";
@@ -654,5 +654,49 @@ describe("SessionList", () => {
     fireEvent.click(getByTestId("sidebar-session-esc"));
     expect(sendSessionInput).toHaveBeenCalledWith("my-agent", "s1", "\x1b");
     expect(onSessionClick).not.toHaveBeenCalled();
+  });
+
+  it("clicking kill button calls onKill with session key after successful deletion", async () => {
+    const { deleteSession } = await import("../api/agentHubClient");
+    (deleteSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined);
+    const onKill = vi.fn();
+    const agents = [makeAgent("my-agent")];
+    const session = makeSession("s1", "my-agent");
+    session.session.state = "running";
+    const { getByTestId } = render(
+      <SessionList
+        {...defaultProps}
+        agents={agents}
+        sessions={[session]}
+        onKill={onKill}
+        isCollapsed={false}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(getByTestId("sidebar-session-kill"));
+    });
+    expect(onKill).toHaveBeenCalledWith("my-agent:s1");
+  });
+
+  it("does not call onKill when deleteSession fails", async () => {
+    const { deleteSession } = await import("../api/agentHubClient");
+    (deleteSession as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network error"));
+    const onKill = vi.fn();
+    const agents = [makeAgent("my-agent")];
+    const session = makeSession("s1", "my-agent");
+    session.session.state = "running";
+    const { getByTestId } = render(
+      <SessionList
+        {...defaultProps}
+        agents={agents}
+        sessions={[session]}
+        onKill={onKill}
+        isCollapsed={false}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(getByTestId("sidebar-session-kill"));
+    });
+    expect(onKill).not.toHaveBeenCalled();
   });
 });

--- a/services/issues-ui/src/components/SessionList.tsx
+++ b/services/issues-ui/src/components/SessionList.tsx
@@ -14,6 +14,7 @@ interface SessionListProps {
   openKeys: Set<string>;
   minimizedKeys: Set<string>;
   onSessionClick: (session: AgentSession) => void;
+  onKill?: (key: string) => void;
   isCollapsed: boolean;
   onToggle: () => void;
 }
@@ -26,7 +27,7 @@ function sessionKey(s: AgentSession): string {
 const DEBUG_SESSION_STATE = false;
 
 
-export function SessionList({ agents, sessions, openKeys, minimizedKeys, onSessionClick, isCollapsed, onToggle }: SessionListProps) {
+export function SessionList({ agents, sessions, openKeys, minimizedKeys, onSessionClick, onKill, isCollapsed, onToggle }: SessionListProps) {
   const { optimisticSetDestroying, optimisticResetState } = useSessionsContext();
 
   const handleKill = async (e: React.MouseEvent, agentName: string, sessionId: string, originalState: string) => {
@@ -34,6 +35,7 @@ export function SessionList({ agents, sessions, openKeys, minimizedKeys, onSessi
     optimisticSetDestroying(sessionId);
     try {
       await deleteSession(agentName, sessionId);
+      onKill?.(`${agentName}:${sessionId}`);
     } catch (err) {
       optimisticResetState(sessionId, originalState);
     }


### PR DESCRIPTION
## Summary

When a session is stopped via the stop button in the sidebar, the associated terminal window/panel now automatically closes.

- Added `onKill?: (key: string) => void` prop to `SessionList`; called after `deleteSession` resolves successfully
- `AgentManager` wires `onKill={handleTerminated}`, reusing the same callback used by `TerminalWindow`'s in-panel stop button
- Window only closes on successful deletion — errors leave the window open and restore the session state

Closes #671

## Test plan

- Added `SessionList` unit tests: `onKill` fires with the correct session key on success; does not fire on failure
- Added `AgentManager` integration test: opening a session then clicking the sidebar kill button removes the window from the tiling layout
- Full test suite: `779 passed` (0 failures)

## UI Tests (issues-ui changes only)

- [x] New/modified components and hooks have co-located interaction-level tests (see `services/issues-ui/CLAUDE.md`)

## Attack Surface / Invariants

N/A — purely a UI state wiring change. No new external inputs, no auth/session lifecycle logic affected. The `deleteSession` call and optimistic state management are unchanged; only the success path closes the panel.