### PR TITLE
feat(#672): make mobile agent console header controls outlined buttons

### DIFF
--- a/services/issues-ui/src/styles/agents.module.css
+++ b/services/issues-ui/src/styles/agents.module.css
@@ -831,7 +831,8 @@
 .mobileCloseButton {
   padding: 0.5rem 0.75rem;
   background: transparent;
-  border: none;
+  border: 1px solid var(--border);
+  border-radius: 3px;
   color: var(--primary);
   font-size: 0.85rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary

- Added `border: 1px solid var(--border)` and `border-radius: 3px` to all mobile session view header buttons (Back, Type…, ↵, Esc, ✕)
- Matches the existing outlined style already used by desktop tile window controls in `TerminalWindow.tsx`

Fixes #672

## Test plan

- [x] All 19 existing `MobileSessionView.test.tsx` tests pass (cover all 5 buttons: render + interaction)
- [x] Shellcheck verification passes
- [x] No changes to component logic — CSS only

## UI Tests (issues-ui changes only)

- [x] New/modified components and hooks have co-located interaction-level tests (see `services/issues-ui/CLAUDE.md`)

## Attack Surface / Invariants

N/A — CSS-only styling change, no logic or state affected