### PR TITLE
fix(#673): use carriage return for text input Enter in notification dropdown

### DIFF
--- a/services/issues-ui/src/components/NotificationDropdown.test.tsx
+++ b/services/issues-ui/src/components/NotificationDropdown.test.tsx
@@ -418,7 +418,7 @@ describe("NotificationDropdown — text input prompt", () => {
     expect(getByTestId("btn-send")).toBeTruthy();
   });
 
-  it("Send button calls sendSessionInput with typed text + \\n", async () => {
+  it("Send button calls sendSessionInput with typed text + \\r", async () => {
     const agentName = "lead";
     const sessionId = "sess-text";
     const sessions = [
@@ -437,7 +437,7 @@ describe("NotificationDropdown — text input prompt", () => {
     fireEvent.click(getByTestId("btn-send"));
 
     await vi.waitFor(() => {
-      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "typed text\n");
+      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "typed text\r");
     });
   });
 });
@@ -719,7 +719,7 @@ describe("NotificationDropdown — select prompt delta variants", () => {
 
 
 describe("NotificationDropdown — text input Enter key submission", () => {
-  it("pressing Enter in the text input calls sendSessionInput with typed text + \\n", async () => {
+  it("pressing Enter in the text input calls sendSessionInput with typed text + \\r", async () => {
     const agentName = "lead";
     const sessionId = "sess-enter";
     const sessions = [
@@ -738,7 +738,7 @@ describe("NotificationDropdown — text input Enter key submission", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     await vi.waitFor(() => {
-      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "hello\n");
+      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "hello\r");
     });
   });
 });

--- a/services/issues-ui/src/components/NotificationDropdown.test.tsx
+++ b/services/issues-ui/src/components/NotificationDropdown.test.tsx
@@ -283,7 +283,7 @@ describe("NotificationDropdown — idle duration", () => {
 // ---------------------------------------------------------------------------
 
 describe("NotificationDropdown — yesno prompt", () => {
-  it("Yes button calls sendSessionInput with 'y\\n'", async () => {
+  it("Yes button calls sendSessionInput with 'y\\r'", async () => {
     const agentName = "lead";
     const sessionId = "sess-yesno";
     const sessions = [
@@ -301,11 +301,11 @@ describe("NotificationDropdown — yesno prompt", () => {
 
     // sendSessionInput is async; wait for it to be called
     await vi.waitFor(() => {
-      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "y\n");
+      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "y\r");
     });
   });
 
-  it("No button calls sendSessionInput with 'n\\n'", async () => {
+  it("No button calls sendSessionInput with 'n\\r'", async () => {
     const agentName = "lead";
     const sessionId = "sess-yesno";
     const sessions = [
@@ -322,7 +322,7 @@ describe("NotificationDropdown — yesno prompt", () => {
     fireEvent.click(getByTestId("btn-no"));
 
     await vi.waitFor(() => {
-      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "n\n");
+      expect(sendSessionInput).toHaveBeenCalledWith(agentName, sessionId, "n\r");
     });
   });
 });

--- a/services/issues-ui/src/components/NotificationDropdown.tsx
+++ b/services/issues-ui/src/components/NotificationDropdown.tsx
@@ -174,7 +174,7 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
             onChange={(e) => { setTextInput(e.target.value); setError(null); }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
-                void handleSend(textInput + "\n");
+                void handleSend(textInput + "\r");
                 setTextInput("");
               }
             }}
@@ -184,7 +184,7 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
             className={layoutStyles.notificationControlBtn}
             disabled={sent}
             onClick={() => {
-              void handleSend(textInput + "\n");
+              void handleSend(textInput + "\r");
               setTextInput("");
             }}
             data-testid="btn-send"

--- a/services/issues-ui/src/components/NotificationDropdown.tsx
+++ b/services/issues-ui/src/components/NotificationDropdown.tsx
@@ -134,7 +134,7 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
           <button
             className={`${layoutStyles.notificationControlBtn} ${layoutStyles.notificationControlBtnPrimary}`}
             disabled={sent}
-            onClick={() => void handleSend("y\n")}
+            onClick={() => void handleSend("y\r")}
             data-testid="btn-yes"
           >
             {sent ? "Sent" : "Yes"}
@@ -142,7 +142,7 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
           <button
             className={layoutStyles.notificationControlBtn}
             disabled={sent}
-            onClick={() => void handleSend("n\n")}
+            onClick={() => void handleSend("n\r")}
             data-testid="btn-no"
           >
             {sent ? "Sent" : "No"}


### PR DESCRIPTION
## Summary

- Changed notification dropdown text input to append `\r` instead of `\n` when submitting text to an agent session
- `\r` (carriage return) is the correct terminal Enter key — consistent with how the mobile dialog sends terminal input via the WebSocket path
- `\n` may not register as Enter in raw-mode terminal prompts (e.g., Claude Code's interactive prompts running in cbreak/raw mode)
- Updated tests to assert `\r` is sent

Fixes #673

## Test plan

- [x] `npm run test` — 786 tests pass
- [x] `shellcheck commands/**/*.sh skills/**/*.sh` passes
- [ ] Manual testing: send text via the notification dropdown to a waiting agent session

## UI Tests (issues-ui changes only)

- [x] New/modified components and hooks have co-located interaction-level tests (see `services/issues-ui/CLAUDE.md`)

## Attack Surface / Invariants

N/A — changes only the newline character appended to user-submitted text; no new trust boundaries or external inputs introduced.