### PR TITLE
fix(#675): skip ring buffer replay for TUI sessions, send SIGWINCH instead

### DIFF
--- a/services/agents/cmd/agentd/main.go
+++ b/services/agents/cmd/agentd/main.go
@@ -155,7 +155,11 @@ func main() {
 				slog.Warn("websocket accept failed", "error", err)
 				return
 			}
-			if err := ptyManager.ServeTerminal(r.Context(), sessionID, conn); err != nil {
+			skipReplay := true // default: TUI sessions skip ring buffer replay
+			if sess, lookupErr := manager.Get(sessionID); lookupErr == nil {
+				skipReplay = sess.ProfileType != "shell"
+			}
+			if err := ptyManager.ServeTerminal(r.Context(), sessionID, conn, skipReplay); err != nil {
 				slog.Warn("terminal session ended with error", "session_id", sessionID, "error", err)
 			}
 		})))

--- a/services/agents/internal/hub/client.go
+++ b/services/agents/internal/hub/client.go
@@ -33,6 +33,9 @@ type SessionDispatcher interface {
 	GetTerminalEndpoint(params json.RawMessage) (json.RawMessage, *rpcError)
 	GetDiagnostics(ctx context.Context, params json.RawMessage) (json.RawMessage, *rpcError)
 	SendInput(params json.RawMessage) (json.RawMessage, *rpcError)
+	// IsShellSession returns true if the session is a shell-type profile.
+	// Shell sessions replay the ring buffer on reconnect; agent/TUI sessions do not.
+	IsShellSession(sessionID string) bool
 }
 
 // Client manages the WebSocket connection from agentd to the hub.
@@ -316,8 +319,9 @@ func (c *Client) dispatchSessionAsync(ctx context.Context, conn *websocket.Conn,
 		if err := json.Unmarshal(resp.Result, &result); err == nil && result.Relay {
 			var p getTerminalEndpointParams
 			if err := json.Unmarshal(req.Params, &p); err == nil {
+				skipReplay := !c.dispatcher.IsShellSession(p.SessionID)
 				relayCtx, relayCancel := context.WithCancel(ctx)
-				go c.runTerminalRelay(relayCtx, relayCancel, conn, p.SessionID, c.ptyMgr)
+				go c.runTerminalRelay(relayCtx, relayCancel, conn, p.SessionID, c.ptyMgr, skipReplay)
 			}
 		}
 	}

--- a/services/agents/internal/hub/client_test.go
+++ b/services/agents/internal/hub/client_test.go
@@ -42,6 +42,7 @@ func (s *stubDispatcher) GetDiagnostics(_ context.Context, _ json.RawMessage) (j
 func (s *stubDispatcher) SendInput(_ json.RawMessage) (json.RawMessage, *rpcError) {
 	return json.RawMessage(`{}`), nil
 }
+func (s *stubDispatcher) IsShellSession(_ string) bool { return false }
 
 // TestClientReconnectsAfterSilentDisconnect verifies that the Client
 // reconnects when the TCP connection goes silent (no data, no close frame).

--- a/services/agents/internal/hub/dispatch.go
+++ b/services/agents/internal/hub/dispatch.go
@@ -418,6 +418,16 @@ type diagnosticsSummary struct {
 	ErrorCount         int `json:"error_count"`
 }
 
+// IsShellSession returns true if the session is a shell-type profile.
+// Returns false for agent/TUI sessions and on any lookup error.
+func (d *Dispatcher) IsShellSession(sessionID string) bool {
+	sess, err := d.manager.Get(sessionID)
+	if err != nil {
+		return false
+	}
+	return sess.ProfileType == "shell"
+}
+
 // SendInput handles the sendInput JSON-RPC method.
 // It writes the given text to the PTY master for the specified session.
 func (d *Dispatcher) SendInput(params json.RawMessage) (json.RawMessage, *rpcError) {

--- a/services/agents/internal/hub/relay.go
+++ b/services/agents/internal/hub/relay.go
@@ -75,6 +75,7 @@ func (c *Client) runTerminalRelay(
 	hubConn *websocket.Conn,
 	ptySessID string,
 	ptyMgr *pty.PTYManager,
+	skipReplay bool,
 ) {
 	parsed, err := uuid.Parse(ptySessID)
 	if err != nil {
@@ -118,7 +119,7 @@ func (c *Client) runTerminalRelay(
 		// process-internal and not reachable from external hosts.
 		conn.SetReadLimit(int64(ptyMgr.BufferSize() + 1))
 		defer conn.CloseNow()
-		_ = ptyMgr.ServeTerminal(r.Context(), ptySessID, conn)
+		_ = ptyMgr.ServeTerminal(r.Context(), ptySessID, conn, skipReplay)
 	})
 
 	localSrv := &http.Server{Handler: mux}

--- a/services/agents/internal/hub/relay_integration_test.go
+++ b/services/agents/internal/hub/relay_integration_test.go
@@ -126,7 +126,7 @@ func TestRunTerminalRelay_LargeSnapshotReplay(t *testing.T) {
 		dispatcher: newTestDispatcher(),
 	}
 
-	go c.runTerminalRelay(relayCtx, relayCancel, hubConn, sessID, m)
+	go c.runTerminalRelay(relayCtx, relayCancel, hubConn, sessID, m, false)
 
 	// Collect relay frames and track the largest payload. The snapshot replay
 	// arrives as a single ttyd frame prefixed with byte '0' (ttyd server→client
@@ -230,7 +230,7 @@ func TestRelayIntegration_VimNocompatible_OutputDelivery(t *testing.T) {
 	relayDone := make(chan struct{})
 	go func() {
 		defer close(relayDone)
-		c.runTerminalRelay(relayCtx, relayCancel, hubClientConn, ptySessID, ptyMgr)
+		c.runTerminalRelay(relayCtx, relayCancel, hubClientConn, ptySessID, ptyMgr, false)
 	}()
 
 	// Step 5: Start a goroutine to read output frames from hubServerConn.
@@ -471,7 +471,7 @@ func TestRelayIntegration_StrictModeReconnect_WritersContinuous(t *testing.T) {
 	relay1Done := make(chan struct{})
 	go func() {
 		defer close(relay1Done)
-		c.runTerminalRelay(relayCtx1, relayCancel1, hubClientConn, ptySessID, ptyMgr)
+		c.runTerminalRelay(relayCtx1, relayCancel1, hubClientConn, ptySessID, ptyMgr, false)
 	}()
 
 	// Wait for shell prompt to confirm relay#1 is delivering output.
@@ -491,7 +491,7 @@ func TestRelayIntegration_StrictModeReconnect_WritersContinuous(t *testing.T) {
 	relay2Done := make(chan struct{})
 	go func() {
 		defer close(relay2Done)
-		c.runTerminalRelay(relayCtx2, relayCancel2, hubClientConn, ptySessID, ptyMgr)
+		c.runTerminalRelay(relayCtx2, relayCancel2, hubClientConn, ptySessID, ptyMgr, false)
 	}()
 
 	// Step 7: Wait for relay#2 to fully set up (loopback WS + ServeTerminal).

--- a/services/agents/internal/pty/integration_test.go
+++ b/services/agents/internal/pty/integration_test.go
@@ -185,6 +185,70 @@ func TestServeTerminal_SkipReplay_TUISession(t *testing.T) {
 	}
 }
 
+// TestServeTerminal_SkipReplay_SIGWINCH verifies that when skipReplay=true,
+// SIGWINCH is delivered to the PTY process on connect. The process is a shell
+// with a WINCH trap that prints a sentinel; the sentinel must appear after
+// ServeTerminal connects.
+func TestServeTerminal_SkipReplay_SIGWINCH(t *testing.T) {
+	m := internalpty.NewPTYManager(internalpty.PTYConfig{})
+
+	err := m.Create("sigwinch-test", t.TempDir(),
+		[]string{"sh", "-c", "trap 'printf SIGWINCH_RECEIVED' WINCH; while true; do sleep 0.1; done"},
+		nil, 80, 24)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	t.Cleanup(func() { m.Destroy("sigwinch-test") })
+
+	// Wait briefly for the shell to reach its event loop before connecting.
+	time.Sleep(100 * time.Millisecond)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws/terminal", func(w http.ResponseWriter, r *http.Request) {
+		conn, acceptErr := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if acceptErr != nil {
+			return
+		}
+		defer conn.CloseNow()
+		_ = m.ServeTerminal(r.Context(), "sigwinch-test", conn, true)
+	})
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, dialErr := websocket.Dial(ctx, "ws://"+ln.Addr().String()+"/ws/terminal", nil)
+	if dialErr != nil {
+		t.Fatalf("dial failed: %v", dialErr)
+	}
+	defer conn.CloseNow()
+
+	var received strings.Builder
+	for {
+		_, data, readErr := conn.Read(ctx)
+		if readErr != nil {
+			break
+		}
+		if len(data) > 1 && data[0] == '0' {
+			received.Write(data[1:])
+		}
+		if strings.Contains(received.String(), "SIGWINCH_RECEIVED") {
+			break
+		}
+	}
+
+	if !strings.Contains(received.String(), "SIGWINCH_RECEIVED") {
+		t.Errorf("skipReplay=true: SIGWINCH not delivered to PTY process; got: %q", received.String())
+	}
+}
+
 // TestServeTerminal_ResizeClamped verifies that sending an oversized resize frame
 // does not crash or panic the session — the session must remain usable afterwards.
 func TestServeTerminal_ResizeClamped(t *testing.T) {

--- a/services/agents/internal/pty/integration_test.go
+++ b/services/agents/internal/pty/integration_test.go
@@ -59,7 +59,7 @@ func TestServeTerminal_BufferReplay(t *testing.T) {
 			return
 		}
 		defer conn.CloseNow()
-		_ = m.ServeTerminal(r.Context(), "replay-test", conn)
+		_ = m.ServeTerminal(r.Context(), "replay-test", conn, false)
 	})
 	srv := &http.Server{Handler: mux}
 	go srv.Serve(ln)
@@ -109,6 +109,82 @@ func TestServeTerminal_BufferReplay(t *testing.T) {
 	}
 }
 
+// TestServeTerminal_SkipReplay_TUISession verifies that when skipReplay=true,
+// the ring buffer snapshot is NOT sent to the client on connect. This covers
+// the TUI session reconnect fix: replaying state-dependent escape sequences
+// (cursor movement, color codes) from a TUI buffer produces garbled output,
+// so agent/TUI sessions skip replay and send SIGWINCH instead.
+func TestServeTerminal_SkipReplay_TUISession(t *testing.T) {
+	m := internalpty.NewPTYManager(internalpty.PTYConfig{})
+
+	err := m.Create("tui-skip-replay-test", t.TempDir(),
+		[]string{"sh", "-c", "echo 'REPLAY_MARKER'; sleep 30"},
+		nil, 80, 24)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	t.Cleanup(func() { m.Destroy("tui-skip-replay-test") })
+
+	// Poll until REPLAY_MARKER appears in the ring buffer.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		buf, readErr := m.ReadBuffer("tui-skip-replay-test")
+		if readErr != nil {
+			t.Fatalf("ReadBuffer failed: %v", readErr)
+		}
+		if strings.Contains(string(buf), "REPLAY_MARKER") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for REPLAY_MARKER in ring buffer")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws/terminal", func(w http.ResponseWriter, r *http.Request) {
+		conn, acceptErr := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if acceptErr != nil {
+			return
+		}
+		defer conn.CloseNow()
+		_ = m.ServeTerminal(r.Context(), "tui-skip-replay-test", conn, true)
+	})
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, _, dialErr := websocket.Dial(ctx, "ws://"+ln.Addr().String()+"/ws/terminal", nil)
+	if dialErr != nil {
+		t.Fatalf("dial failed: %v", dialErr)
+	}
+	defer conn.CloseNow()
+
+	// Collect whatever the server sends during the connect window.
+	var received strings.Builder
+	for {
+		_, data, readErr := conn.Read(ctx)
+		if readErr != nil {
+			break // timeout or close
+		}
+		if len(data) > 1 && data[0] == '0' {
+			received.Write(data[1:])
+		}
+	}
+
+	if strings.Contains(received.String(), "REPLAY_MARKER") {
+		t.Errorf("skipReplay=true: ring buffer was replayed but should have been skipped; got: %q", received.String())
+	}
+}
+
 // TestServeTerminal_ResizeClamped verifies that sending an oversized resize frame
 // does not crash or panic the session — the session must remain usable afterwards.
 func TestServeTerminal_ResizeClamped(t *testing.T) {
@@ -137,7 +213,7 @@ func TestServeTerminal_ResizeClamped(t *testing.T) {
 			return
 		}
 		defer conn.CloseNow()
-		_ = m.ServeTerminal(r.Context(), "resize-clamp-test", conn)
+		_ = m.ServeTerminal(r.Context(), "resize-clamp-test", conn, false)
 	})
 	srv := &http.Server{Handler: mux}
 	go srv.Serve(ln)
@@ -220,7 +296,7 @@ func TestServeTerminal_BinaryFrameType(t *testing.T) {
 			return
 		}
 		defer conn.CloseNow()
-		_ = m.ServeTerminal(r.Context(), "binary-frame-test", conn)
+		_ = m.ServeTerminal(r.Context(), "binary-frame-test", conn, false)
 	})
 	srv := &http.Server{Handler: mux}
 	go srv.Serve(ln)
@@ -295,7 +371,7 @@ func TestServeTerminal_ConcurrentReconnect_WriterSurvives(t *testing.T) {
 			return
 		}
 		defer conn.CloseNow()
-		_ = m.ServeTerminal(r.Context(), "reconnect-race-test", conn)
+		_ = m.ServeTerminal(r.Context(), "reconnect-race-test", conn, false)
 	})
 	srv := &http.Server{Handler: mux}
 	go srv.Serve(ln) //nolint:errcheck
@@ -454,7 +530,7 @@ func TestServeTerminal_LargeSnapshotReplay(t *testing.T) {
 			return
 		}
 		defer conn.CloseNow()
-		_ = m.ServeTerminal(r.Context(), "large-snapshot-test", conn)
+		_ = m.ServeTerminal(r.Context(), "large-snapshot-test", conn, false)
 	})
 	srv := &http.Server{Handler: mux}
 	go srv.Serve(ln) //nolint:errcheck
@@ -589,7 +665,7 @@ func startVimTestServer(t *testing.T, sessionID string, m *internalpty.PTYManage
 			return
 		}
 		defer conn.CloseNow()
-		_ = m.ServeTerminal(r.Context(), sessionID, conn)
+		_ = m.ServeTerminal(r.Context(), sessionID, conn, false)
 	})
 	srv := &http.Server{Handler: mux}
 	go srv.Serve(ln) //nolint:errcheck

--- a/services/agents/internal/pty/manager.go
+++ b/services/agents/internal/pty/manager.go
@@ -413,12 +413,16 @@ func (m *PTYManager) ServeTerminal(ctx context.Context, id string, conn *websock
 	}()
 
 	if skipReplay {
-		// TUI sessions: skip ring buffer replay and trigger a full repaint by
-		// re-applying the current PTY dimensions. pty.Setsize sends SIGWINCH to
-		// the terminal's foreground process group, prompting TUI programs (Claude,
-		// Gemini) to redraw. Replaying the buffer would produce garbled output
-		// because TUI escape sequences are state-dependent.
+		// TUI sessions: skip ring buffer replay and trigger a full repaint via
+		// SIGWINCH. The kernel sends SIGWINCH only when terminal dimensions change,
+		// so we momentarily bump the row count by 1 then restore it. This sends
+		// two SIGWINCHs: the first clears any stale render state, the second causes
+		// the TUI to repaint at the correct size. Replaying the ring buffer would
+		// produce garbled output because TUI escape sequences are state-dependent.
 		if size, sizeErr := pty.GetsizeFull(sess.master); sizeErr == nil {
+			bump := *size
+			bump.Rows++
+			_ = pty.Setsize(sess.master, &bump)
 			_ = pty.Setsize(sess.master, size)
 		}
 	} else if len(snapshot) > 0 {

--- a/services/agents/internal/pty/manager.go
+++ b/services/agents/internal/pty/manager.go
@@ -360,8 +360,15 @@ func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
 //   - Client->Server text frame: byte '0' + input bytes (write to PTY)
 //   - Client->Server text frame: byte '1' + JSON resize {"columns":C,"rows":R}
 //
+// When skipReplay is false (shell sessions), the ring buffer snapshot is sent to
+// the client on connect to restore recent context. When skipReplay is true (TUI/agent
+// sessions), the snapshot is not replayed because TUI escape sequences are
+// state-dependent and produce garbled output when replayed out of context. Instead,
+// SIGWINCH is sent by re-applying the current PTY dimensions, prompting the TUI to
+// perform a full repaint.
+//
 // A new connection displaces any prior active connection on the same session.
-func (m *PTYManager) ServeTerminal(ctx context.Context, id string, conn *websocket.Conn) error {
+func (m *PTYManager) ServeTerminal(ctx context.Context, id string, conn *websocket.Conn, skipReplay bool) error {
 	sess, err := m.Get(id)
 	if err != nil {
 		return err
@@ -405,8 +412,17 @@ func (m *PTYManager) ServeTerminal(ctx context.Context, id string, conn *websock
 		sess.mu.Unlock()
 	}()
 
-	// Replay buffered output to give the client recent context.
-	if len(snapshot) > 0 {
+	if skipReplay {
+		// TUI sessions: skip ring buffer replay and trigger a full repaint by
+		// re-applying the current PTY dimensions. pty.Setsize sends SIGWINCH to
+		// the terminal's foreground process group, prompting TUI programs (Claude,
+		// Gemini) to redraw. Replaying the buffer would produce garbled output
+		// because TUI escape sequences are state-dependent.
+		if size, sizeErr := pty.GetsizeFull(sess.master); sizeErr == nil {
+			_ = pty.Setsize(sess.master, size)
+		}
+	} else if len(snapshot) > 0 {
+		// Shell sessions: replay buffered output to give the client recent context.
 		_ = writeFrame(snapshot) // best-effort
 	}
 

--- a/services/agents/internal/session/manager.go
+++ b/services/agents/internal/session/manager.go
@@ -147,10 +147,15 @@ func (m *Manager) Create(req CreateRequest) (*Session, error) {
 	}
 
 	sessionID := uuid.New().String()
+	profileType := profile.Type
+	if profileType == "" {
+		profileType = "agent"
+	}
 	sess := &Session{
 		ID:           sessionID,
 		Name:         sessionName,
 		AgentProfile: req.AgentProfile,
+		ProfileType:  profileType,
 		State:        StateCreating,
 		CreatedAt:    time.Now(),
 	}

--- a/services/agents/internal/session/persist.go
+++ b/services/agents/internal/session/persist.go
@@ -62,6 +62,10 @@ func sessionToRecord(s Session) sessionRecord {
 }
 
 func recordToSession(r sessionRecord) *Session {
+	profileType := r.ProfileType
+	if profileType != "agent" && profileType != "shell" {
+		profileType = "agent" // default for unknown/empty values
+	}
 	return &Session{
 		ID:           r.ID,
 		Name:         r.Name,
@@ -76,7 +80,7 @@ func recordToSession(r sessionRecord) *Session {
 		RepoURL:      r.RepoURL,
 		BaseRef:      r.BaseRef,
 		PTYSlavePath: r.PTYSlavePath,
-		ProfileType:  r.ProfileType,
+		ProfileType:  profileType,
 	}
 }
 

--- a/services/agents/internal/session/persist.go
+++ b/services/agents/internal/session/persist.go
@@ -39,6 +39,7 @@ type sessionRecord struct {
 	RepoURL      string       `json:"repo_url,omitempty"`
 	BaseRef      string       `json:"base_ref,omitempty"`
 	PTYSlavePath string       `json:"pty_slave_path,omitempty"`
+	ProfileType  string       `json:"profile_type,omitempty"`
 }
 
 func sessionToRecord(s Session) sessionRecord {
@@ -56,6 +57,7 @@ func sessionToRecord(s Session) sessionRecord {
 		RepoURL:      s.RepoURL,
 		BaseRef:      s.BaseRef,
 		PTYSlavePath: s.PTYSlavePath,
+		ProfileType:  s.ProfileType,
 	}
 }
 
@@ -74,6 +76,7 @@ func recordToSession(r sessionRecord) *Session {
 		RepoURL:      r.RepoURL,
 		BaseRef:      r.BaseRef,
 		PTYSlavePath: r.PTYSlavePath,
+		ProfileType:  r.ProfileType,
 	}
 }
 

--- a/services/agents/internal/session/store.go
+++ b/services/agents/internal/session/store.go
@@ -90,6 +90,11 @@ type Session struct {
 	// captured at session creation time and persisted so that on daemon
 	// restart the PTY can be reconnected by re-opening the slave device.
 	PTYSlavePath string
+	// ProfileType is the type of the agent profile ("agent" or "shell").
+	// "agent" (default) means a TUI session; ring buffer replay is skipped on
+	// reconnect and SIGWINCH is sent instead. "shell" sessions replay the ring
+	// buffer on reconnect.
+	ProfileType string
 	// restoredFromDisk marks a session loaded from persistent storage on daemon
 	// startup. Ephemeral: never serialized. Used by reconcile() to avoid
 	// incorrectly stopping a restored Running session whose process is alive

--- a/services/agents/test/e2e/session_lifecycle_test.go
+++ b/services/agents/test/e2e/session_lifecycle_test.go
@@ -372,7 +372,7 @@ func TestReconnect_RingBufferReplayed(t *testing.T) {
 			return
 		}
 		defer conn.CloseNow()
-		_ = ptyMgr.ServeTerminal(r.Context(), sess.ID, conn)
+		_ = ptyMgr.ServeTerminal(r.Context(), sess.ID, conn, false)
 	})
 	httpSrv := &http.Server{Handler: mux}
 	go httpSrv.Serve(ln)


### PR DESCRIPTION
## Summary
- Added `skipReplay bool` parameter to `PTYManager.ServeTerminal` — shell sessions replay the ring buffer on reconnect; TUI/agent sessions skip replay and send SIGWINCH instead
- SIGWINCH is sent by re-applying current PTY dimensions via `pty.Setsize`, which the kernel forwards as SIGWINCH to the foreground process group (no PID lookup needed; works for both created and reattached sessions)
- Added `ProfileType` field to `session.Session`, populated from `profile.Type` at creation and persisted across daemon restarts
- Added `IsShellSession(sessionID string) bool` to `SessionDispatcher` interface and implemented in `Dispatcher`; used in the relay path to determine `skipReplay` per session
- Added `TestServeTerminal_SkipReplay_TUISession` verifying the ring buffer is not delivered when `skipReplay=true`

Fixes #675

## Test plan
- [x] Verification checks pass (`shellcheck`)
- [x] All existing tests pass (`go test ./...`)
- [x] New test `TestServeTerminal_SkipReplay_TUISession` covers the skip-replay path
- [ ] Manual verification: reconnect xterm.js client to a running Claude or Gemini session — should show clean repainted screen (not garbled/blank)