### PR TITLE
fix(#677): stop agent disconnect loop from oversized prompt_context

### DIFF
--- a/services/agent-hub/internal/hub/hub.go
+++ b/services/agent-hub/internal/hub/hub.go
@@ -30,11 +30,13 @@ const maxConsecutiveRPCFailures = 3
 const MaxMessageSize = 1 << 20
 
 // RPCMaxMessageSize is the maximum allowed size for a single JSON-RPC
-// (text) frame from an agent (64 KiB). RPC payloads (register, ping/pong,
-// listSessions, createSession responses) are structurally small — a 1 MiB
-// text frame would never occur in normal operation and likely indicates a
-// misconfigured or malicious client. Enforced post-read in HandleAgentConnection.
-const RPCMaxMessageSize = 64 * 1024
+// (text) frame from an agent (512 KiB). listSessions responses carry
+// prompt_context, which is derived from PTY scrollback: TUI agents redraw
+// with cursor movement rather than newlines, so "15 lines" of context can
+// span hundreds of KiB and a 64 KiB cap disconnected agents in a reconnect
+// loop. Must stay below MaxMessageSize so oversized text frames reach the
+// post-read check in HandleAgentConnection instead of dying at SetReadLimit.
+const RPCMaxMessageSize = 512 * 1024
 
 // Hub manages registered agentd connections.
 type Hub struct {

--- a/services/agents/internal/session/monitor.go
+++ b/services/agents/internal/session/monitor.go
@@ -195,9 +195,12 @@ func lastNLines(s string, n int) string {
 	return strings.Join(nonEmpty, "\n")
 }
 
-// truncateTail keeps the last max bytes of s, trimming a partial rune and a
-// partial leading line so the result starts on a line boundary.
+// truncateTail keeps the last max bytes of s, trimming a partial rune and,
+// when possible, a partial leading line.
 func truncateTail(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
 	if len(s) <= max {
 		return s
 	}

--- a/services/agents/internal/session/monitor.go
+++ b/services/agents/internal/session/monitor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dokipen/claude-cadence/services/agents/internal/pty"
 )
@@ -26,6 +27,12 @@ var (
 // idleThreshold is how long content must be unchanged with a prompt before
 // marking the session as waiting for input.
 const idleThreshold = 10 * time.Second
+
+// maxPromptContextBytes caps PromptContext. TUI agents redraw via cursor
+// movement rather than newlines, so "15 lines" of scrollback can span nearly
+// the whole PTY ring buffer (~1 MiB) — far past the hub's per-frame RPC limit,
+// which gets the agent disconnected. The prompt is at the tail, so keep that.
+const maxPromptContextBytes = 8 * 1024
 
 // sessionSnapshot tracks the last observed pane content for change detection.
 type sessionSnapshot struct {
@@ -147,7 +154,7 @@ func (m *Monitor) check() {
 		idleDuration := now.Sub(snap.firstSeen)
 		if idleDuration >= idleThreshold && !sess.WaitingForInput {
 			idleSince := snap.firstSeen
-			ctx := lastNLines(stripANSI(content), 15)
+			ctx := truncateTail(lastNLines(stripANSI(content), 15), maxPromptContextBytes)
 			promptType := classifyPromptType(ctx)
 			_, _ = m.manager.store.Update(sess.ID, func(s *Session) {
 				s.WaitingForInput = true
@@ -186,6 +193,22 @@ func lastNLines(s string, n int) string {
 		nonEmpty = nonEmpty[len(nonEmpty)-n:]
 	}
 	return strings.Join(nonEmpty, "\n")
+}
+
+// truncateTail keeps the last max bytes of s, trimming a partial rune and a
+// partial leading line so the result starts on a line boundary.
+func truncateTail(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	s = s[len(s)-max:]
+	for len(s) > 0 && !utf8.RuneStart(s[0]) {
+		s = s[1:]
+	}
+	if i := strings.IndexByte(s, '\n'); i >= 0 && i < len(s)-1 {
+		s = s[i+1:]
+	}
+	return s
 }
 
 func classifyPromptType(context string) string {

--- a/services/agents/internal/session/monitor_test.go
+++ b/services/agents/internal/session/monitor_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dokipen/claude-cadence/services/agents/internal/pty"
 )
@@ -476,6 +477,81 @@ func TestLastNLines(t *testing.T) {
 			got := lastNLines(tt.input, tt.n)
 			if got != tt.want {
 				t.Errorf("lastNLines(%q, %d) = %q, want %q", tt.input, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTruncateTail verifies that truncateTail keeps the last max bytes,
+// never splits a multibyte rune, trims a partial leading line when possible,
+// and returns "" for non-positive max.
+func TestTruncateTail(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		max   int
+		want  string
+	}{
+		{
+			name:  "shorter than max is a no-op",
+			input: "hello",
+			max:   10,
+			want:  "hello",
+		},
+		{
+			name:  "length exactly max is a no-op",
+			input: "hello",
+			max:   5,
+			want:  "hello",
+		},
+		{
+			name:  "max zero returns empty",
+			input: "hello",
+			max:   0,
+			want:  "",
+		},
+		{
+			name:  "max negative returns empty",
+			input: "hello",
+			max:   -1,
+			want:  "",
+		},
+		{
+			name:  "cut mid-rune trims to rune boundary",
+			input: "aa€bb", // '€' is 3 bytes; max 4 lands inside it
+			max:   4,
+			want:  "bb",
+		},
+		{
+			name:  "no newlines keeps raw tail (TUI case)",
+			input: "abcdefghij",
+			max:   5,
+			want:  "fghij",
+		},
+		{
+			name:  "newline as final byte keeps mid-line string",
+			input: "abcdef\n",
+			max:   4,
+			want:  "def\n",
+		},
+		{
+			name:  "trims partial leading line to clean following line",
+			input: "line1\nline2\nline3",
+			max:   8,
+			want:  "line3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateTail(tt.input, tt.max)
+			if got != tt.want {
+				t.Errorf("truncateTail(%q, %d) = %q, want %q", tt.input, tt.max, got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateTail(%q, %d) = %q is not valid UTF-8", tt.input, tt.max, got)
+			}
+			if got != "" && !utf8.RuneStart(got[0]) {
+				t.Errorf("truncateTail(%q, %d) = %q does not start at a rune boundary", tt.input, tt.max, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes claude-cadence ticket #677 (issues-api): the mac agent flapped on/off the hub in a permanent reconnect loop — 16,281 occurrences of `StatusMessageTooBig / "RPC frame exceeds limit"` in its log.

Root cause: `PromptContext` is built as the "last 15 lines" of PTY scrollback, but TUI agents (claude, gemini) redraw with cursor-movement escapes rather than newlines, so those "15 lines" can span nearly the entire ~1 MiB ring buffer. The oversized `listSessions` response tripped the hub's 64 KiB `RPCMaxMessageSize`, the hub closed the connection, agentd reconnected, the hub called `listSessions` again — same frame, same close, forever. Restarting agentd never helped because the buffer refills as soon as the session idles at a prompt again.

Two changes, both needed:

- **agentd** (`services/agents/internal/session/monitor.go`): cap `PromptContext` at 8 KiB via `truncateTail`, keeping the tail (where the prompt is) and trimming to rune/line boundaries. This bounds the payload at the source — a worst-case context could exceed even the 1 MiB connection read limit, so no hub-side limit alone can fully close the bug.
- **hub** (`services/agent-hub/internal/hub/hub.go`): raise `RPCMaxMessageSize` 64 KiB → 512 KiB for headroom. Kept strictly below `MaxMessageSize` (1 MiB) so oversized text frames still reach the post-read check and produce the explicit close + log instead of dying opaquely at `SetReadLimit` (invariant enforced by `TestMaxMessageSizeConstants`).

## Test plan

- `go test ./...` — green in both `services/agent-hub` and `services/agents` (includes the oversized-frame close test and the `RPCMaxMessageSize < MaxMessageSize` invariant test)
- `make build build-linux` — clean for both services
- `shellcheck commands/**/*.sh skills/**/*.sh` — clean
- Manual QA pending: deploy hub to bootsy (`deploy-all.sh --skip-agents`), then agentd, and confirm `grep -c "RPC frame exceeds limit" agentd.log` stops incrementing (ticket #677 acceptance criteria)

## UI Tests (issues-ui changes only)

N/A — no `services/issues-ui/` changes.

## Attack Surface / Invariants

1. **Invariants**: `RPCMaxMessageSize < MaxMessageSize` (oversized text frames must reach the post-read check for the explicit close + structured log, rather than an opaque read-limit kill) — still enforced by `TestMaxMessageSizeConstants`. `PromptContext ≤ 8 KiB` at the producer, so `listSessions` responses stay far below the frame cap regardless of session age or TUI redraw behavior.
2. **If violated**: an agent with a long-lived TUI session gets disconnected on every `listSessions`, flapping offline permanently (the exact #677 failure).
3. **New trust boundaries / inputs**: none. The hub still enforces its limit on untrusted agent frames — the cap is loosened 8x but remains half the connection-level read limit; no unbounded input is newly accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)