### PR TITLE
fix(#685): stop closing the agent connection on message size; bound payloads by construction

### DIFF
--- a/docs/runbooks/agentd-mac-dead.md
+++ b/docs/runbooks/agentd-mac-dead.md
@@ -1,0 +1,200 @@
+# Runbook: `mac` agentd missing / "dead" in the dashboard
+
+**Symptom:** the `mac` host is missing from "available hosts" in the claude-cadence
+dashboard, or it blinks in and out.
+
+**Key fact:** agentd on `mac` talks to the hub over an **outbound** WebSocket — it
+dials the hub, the hub never dials agentd (see
+[`skills/agent-service/SKILL.md`](../../skills/agent-service/SKILL.md), "host loopback
+only"). So "mac is gone" almost never means the process crashed. It usually means the
+**registration with the hub is broken** while the process is still alive.
+
+There are three distinct failure modes. Triage tells you which one you have — **the fix
+differs**, and for one of them restarting does **not** help.
+
+---
+
+## Reference facts
+
+| Thing | Value |
+|---|---|
+| launchd label | `com.cadence.agentd` |
+| Binary | `/Users/bob/bin/agentd` |
+| Config | `~/.config/agentd/config.yaml` (operator-managed — do **not** read programmatically; it triggers macOS popups) |
+| Log | `/Users/bob/lib/agentd/agentd.log` |
+| Hub | `cadence.whatisbackdoor.com` → `192.168.86.28` (`bootsy.lan`), `:443` |
+| Terminal listener | `:8001` on the LAN IP (`advertise_address`) — LAN-bound by design, **not** localhost |
+
+---
+
+## Step 1 — Triage (always run this first)
+
+```bash
+# Is the process alive and managed by launchd?
+pgrep -lf '/Users/bob/bin/agentd'
+launchctl list | grep -i cadence
+
+# What does the hub actually think? (authoritative for the dashboard)
+curl -s -m 8 https://cadence.whatisbackdoor.com/api/v1/agents \
+  | jq -r '.agents[] | "\(.name)  status=\(.status)  last_seen=\(.last_seen)"'
+
+# What is agentd's own recent history?
+tail -30 /Users/bob/lib/agentd/agentd.log
+```
+
+Now match what you see to one of the three modes below.
+
+---
+
+## Mode A — Process is dead / launchd not running it
+
+**Signature:**
+- `pgrep` returns nothing, **or** `launchctl list | grep cadence` shows no
+  `com.cadence.agentd` line (or a non-zero exit status in the middle column).
+
+**Fix:**
+```bash
+launchctl kickstart -k gui/$(id -u)/com.cadence.agentd
+```
+If it immediately dies again, read the tail of the log for a startup/config error and
+escalate to the operator (config is operator-managed).
+
+---
+
+## Mode B — Zombie / stale WebSocket (process up, hub doesn't list mac)
+
+**Signature:**
+- `pgrep` shows a live agentd PID.
+- The hub agents list does **not** include `mac` (only `bootsy`, etc.).
+- agentd holds a TCP socket to the hub but its log shows **no recent**
+  `reconnecting to hub` / `connected to hub` activity — it has believed it was
+  "connected" for hours or days.
+
+```bash
+# Confirm: socket open at the OS level, but app-level registration is dead
+lsof -nP -a -p "$(pgrep -f '/Users/bob/bin/agentd')" -iTCP -sTCP:ESTABLISHED | grep ':443'
+```
+
+**Cause:** the hub on bootsy was restarted (wipes its in-memory agent registry), but
+mac's TCP socket stayed half-open, so agentd never noticed and never re-registered.
+
+**Fix:** restart agentd to force a fresh handshake.
+```bash
+launchctl kickstart -k gui/$(id -u)/com.cadence.agentd
+```
+
+**Verify:**
+```bash
+# Expect a fresh "connected to hub" line, then mac appears online
+tail -6 /Users/bob/lib/agentd/agentd.log
+curl -s -m 8 https://cadence.whatisbackdoor.com/api/v1/agents \
+  | jq -r '.agents[] | "\(.name)  status=\(.status)"'
+```
+
+> Restarting drops any sessions whose processes are already dead (logged as
+> `auto-destroying session: process no longer alive`) — that's cleanup, not lost work.
+> But it **will** interrupt genuinely live sessions, so check the session list first if
+> work is in flight.
+
+---
+
+## Mode C — Frame-too-big flapping (mac blinks online/offline)
+
+**Signature:**
+- The hub list shows `mac` intermittently — online one moment, gone the next.
+- `last_seen` for `mac` stops advancing for ~30s, then the host drops and returns.
+- The log shows a repeating cycle, possibly dozens of times:
+  ```
+  WARN hub connection failed: received close frame:
+       status = StatusMessageTooBig, reason = "..."
+  INFO reconnecting to hub
+  INFO connected to hub
+  ```
+- The trigger is often **user-visible**: hovering a session in the sidebar, or opening
+  a terminal panel for a long-lived session, knocks the host offline.
+- `GET /api/v1/agents/mac/sessions` may return `{"error":"agent offline"}` if you query
+  during a down-swing.
+
+```bash
+# How pervasive is it?
+grep -c "StatusMessageTooBig" /Users/bob/lib/agentd/agentd.log
+```
+
+**Cause:** a single WebSocket message from agentd exceeded the hub's read limit on the
+agent connection, and the hub (or the websocket library) responded by closing the
+**whole** connection — taking every relayed terminal with it and marking the host
+offline. agentd reconnects, the same message is sent again, and the cycle repeats.
+
+Two concrete instances were found (both fixed in **#685**):
+
+1. **Relay snapshot replay, 17 bytes over.** Hovering/opening a session replays the
+   session's PTY ring buffer through the relay. A full buffer (`1 MiB − 1`) plus the
+   ttyd prefix (1) plus the relay header (17) is 1,048,593 bytes — but the hub's read
+   limit was exactly 1,048,576. Any session with ≥1 MiB of scrollback (every
+   long-running Claude TUI session gets there within minutes) was a "poison" session:
+   hovering it dropped the host. This is what caused the 2026-08-23 outage
+   (`discuss-47`).
+2. **Oversized `listSessions` reply** (#677 / PR #785). `prompt_context` for many TUI
+   sessions blew past the hub's 64 KiB RPC frame check, which closed the connection.
+
+> The earlier theory in this runbook — a persisted session record pushed to the hub on
+> connect — was wrong. The ~8s-after-connect close was the UI reopening the terminal
+> relay (and replaying the snapshot) after each reconnect.
+
+**Post-#685 state:** the hub no longer closes the agent connection or marks an agent
+offline because of message size; the only limit left is a 16 MiB bug backstop
+(`services/shared/relay.AgentMaxMessageSize`), the hub advertises that limit to agentd
+in the `register` response, agentd refuses to send RPC replies over the negotiated
+limit (degrading `prompt_context` first), and `listSessions` is metadata-only. If Mode C
+recurs after #685 is deployed on **both** hosts, it is a new bug — collect the log line
+with the frame size and escalate.
+
+**If you are on a pre-#685 build — mitigation:**
+
+- A plain `kickstart` restart alone does NOT help while the poison session is still
+  live — agentd restores it and the next hover/terminal-open replays the same frame.
+- The hub session API is unreachable during a down-swing, so you may not be able to
+  destroy the session through the hub. If you can catch an up-swing,
+  `DELETE /api/v1/agents/mac/sessions/<id>` works.
+
+Otherwise clear it locally:
+1. Kill the offending session's live process so agentd will treat it as dead:
+   ```bash
+   # find session processes (children of agentd)
+   pgrep -P "$(pgrep -f '/Users/bob/bin/agentd')"
+   kill <session-pid>
+   ```
+2. Restart agentd. On startup it restores persisted sessions and **auto-destroys any
+   whose process is no longer alive**:
+   ```bash
+   launchctl kickstart -k gui/$(id -u)/com.cadence.agentd
+   ```
+   Expect log lines: `restored persisted sessions` → `auto-destroying session: process
+   no longer alive` → `connected to hub`.
+3. Verify no renewed flapping and that mac stays registered:
+   ```bash
+   grep -c "StatusMessageTooBig" /Users/bob/lib/agentd/agentd.log   # watch it stop climbing
+   curl -s -m 8 https://cadence.whatisbackdoor.com/api/v1/agents \
+     | jq -r '.agents[] | "\(.name)  status=\(.status)"'
+   ```
+4. Deploy the #685 builds of **both** `agent-hub` (bootsy) and `agentd` (mac). The
+   relay fix is hub-side only, so deploying the hub alone stops the hover-triggered
+   drops; the agentd half adds the negotiated limit and sender-side degrade.
+
+---
+
+## Decision tree (quick reference)
+
+```
+mac missing from dashboard?
+├─ No agentd process / not in launchctl ............... Mode A → kickstart
+├─ Process up, hub omits mac, log quiet (stale) ....... Mode B → kickstart
+└─ Log shows StatusMessageTooBig closes, mac blinks .... Mode C → DO NOT just restart;
+                                                                  clear session / code fix
+```
+
+## Escalation
+
+- Config errors on startup, or repeated Mode C → owner of `services/agent-hub` / the
+  agentd daemon.
+- `~/.config/agentd/config.yaml` is operator-managed; agents must not read it.

--- a/services/agent-hub/internal/hub/agent.go
+++ b/services/agent-hub/internal/hub/agent.go
@@ -46,6 +46,10 @@ type ConnectedAgent struct {
 // CloseTerminalChannel, and CloseTerminalChannels), so a relay that the hub
 // tore down on disconnect can still be cleaned up by its owner without a
 // double-close panic.
+//
+// Invariant: relay channels are only ever closed while holding terminalMu,
+// and DeliverTerminalFrame performs its (non-blocking) send while holding
+// terminalMu, so a send can never race a close and panic.
 type terminalRelay struct {
 	ch        chan []byte
 	closeOnce sync.Once
@@ -132,35 +136,42 @@ func (a *ConnectedAgent) RegisterTerminalRelay(sessionID uuid.UUID) (<-chan []by
 
 	cleanup := func() {
 		a.terminalMu.Lock()
+		defer a.terminalMu.Unlock()
 		// Only delete if the map still points to OUR relay.
 		if a.terminalChannels[sessionID] == relay {
 			delete(a.terminalChannels, sessionID)
 		}
-		a.terminalMu.Unlock()
-		// Idempotent: safe even if CloseTerminalChannel(s) already closed it.
+		// Close under terminalMu (see terminalRelay invariant) so it cannot
+		// race a concurrent DeliverTerminalFrame send. Idempotent: safe even
+		// if CloseTerminalChannel(s) already closed it.
 		relay.close()
 	}
 	return relay.ch, cleanup
 }
 
 // DeliverTerminalFrame routes a decoded frame payload to the channel registered
-// for sessionID. Returns false if no relay is registered for that session.
+// for sessionID. Returns false if no relay is registered for that session, or
+// if the relay's buffer is full and the frame was dropped.
+//
+// The lookup, payload copy, and non-blocking send all happen while holding
+// terminalMu. Channels are only closed while holding terminalMu, so the send
+// can never race a close. The send is non-blocking (select/default), so
+// holding the lock across it cannot stall other terminalMu users.
 func (a *ConnectedAgent) DeliverTerminalFrame(sessionID uuid.UUID, payload []byte) bool {
 	a.terminalMu.Lock()
-	relay, ok := a.terminalChannels[sessionID]
-	a.terminalMu.Unlock()
+	defer a.terminalMu.Unlock()
 
+	relay, ok := a.terminalChannels[sessionID]
 	if !ok {
 		return false
 	}
-	ch := relay.ch
 
 	// Copy payload so the caller's buffer can be reused.
 	buf := make([]byte, len(payload))
 	copy(buf, payload)
 
 	select {
-	case ch <- buf:
+	case relay.ch <- buf:
 		return true
 	default:
 		// Channel full — drop the frame rather than blocking the read loop.
@@ -174,6 +185,7 @@ func (a *ConnectedAgent) DeliverTerminalFrame(sessionID uuid.UUID, payload []byt
 
 // CloseTerminalChannel closes the relay channel for a single session and removes
 // it from the map. Safe to call when no relay is registered for the session.
+// The close happens under terminalMu (see terminalRelay invariant).
 func (a *ConnectedAgent) CloseTerminalChannel(sessionID uuid.UUID) {
 	a.terminalMu.Lock()
 	defer a.terminalMu.Unlock()
@@ -185,7 +197,8 @@ func (a *ConnectedAgent) CloseTerminalChannel(sessionID uuid.UUID) {
 
 // CloseTerminalChannels closes all terminal relay channels and clears the map.
 // This unblocks any relay goroutines waiting on the channels, causing them to
-// see ok=false and clean up.
+// see ok=false and clean up. Closes happen under terminalMu (see terminalRelay
+// invariant).
 func (a *ConnectedAgent) CloseTerminalChannels() {
 	a.terminalMu.Lock()
 	defer a.terminalMu.Unlock()

--- a/services/agent-hub/internal/hub/agent.go
+++ b/services/agent-hub/internal/hub/agent.go
@@ -30,15 +30,29 @@ type ConnectedAgent struct {
 	Profiles   map[string]ProfileInfo `json:"profiles"`
 	TtydConfig TtydInfo               `json:"ttyd"`
 
-	mu                    sync.Mutex
-	status                AgentStatus
-	lastSeen              time.Time
-	conn                  *websocket.Conn
-	pending               map[string]chan *Response
+	mu                     sync.Mutex
+	status                 AgentStatus
+	lastSeen               time.Time
+	conn                   *websocket.Conn
+	pending                map[string]chan *Response
 	consecutiveRPCFailures int
 
 	terminalMu       sync.Mutex
-	terminalChannels map[uuid.UUID]chan []byte
+	terminalChannels map[uuid.UUID]*terminalRelay
+}
+
+// terminalRelay is one registered relay channel. The close-once guard makes
+// closing idempotent across all closers (the registration's cleanup func,
+// CloseTerminalChannel, and CloseTerminalChannels), so a relay that the hub
+// tore down on disconnect can still be cleaned up by its owner without a
+// double-close panic.
+type terminalRelay struct {
+	ch        chan []byte
+	closeOnce sync.Once
+}
+
+func (r *terminalRelay) close() {
+	r.closeOnce.Do(func() { close(r.ch) })
 }
 
 // NewConnectedAgent creates a new agent entry.
@@ -51,7 +65,7 @@ func NewConnectedAgent(name string, conn *websocket.Conn, params *RegisterParams
 		lastSeen:         time.Now(),
 		conn:             conn,
 		pending:          make(map[string]chan *Response),
-		terminalChannels: make(map[uuid.UUID]chan []byte),
+		terminalChannels: make(map[uuid.UUID]*terminalRelay),
 	}
 }
 
@@ -110,37 +124,36 @@ func (a *ConnectedAgent) Touch() {
 // removes the registration and closes the channel. Calling the cleanup
 // function more than once is safe.
 func (a *ConnectedAgent) RegisterTerminalRelay(sessionID uuid.UUID) (<-chan []byte, func()) {
-	ch := make(chan []byte, terminalChannelBufSize)
+	relay := &terminalRelay{ch: make(chan []byte, terminalChannelBufSize)}
 
 	a.terminalMu.Lock()
-	a.terminalChannels[sessionID] = ch
+	a.terminalChannels[sessionID] = relay
 	a.terminalMu.Unlock()
 
-	var once sync.Once
 	cleanup := func() {
-		once.Do(func() {
-			a.terminalMu.Lock()
-			// Only delete if the map still points to OUR channel.
-			if a.terminalChannels[sessionID] == ch {
-				delete(a.terminalChannels, sessionID)
-			}
-			a.terminalMu.Unlock()
-			close(ch)
-		})
+		a.terminalMu.Lock()
+		// Only delete if the map still points to OUR relay.
+		if a.terminalChannels[sessionID] == relay {
+			delete(a.terminalChannels, sessionID)
+		}
+		a.terminalMu.Unlock()
+		// Idempotent: safe even if CloseTerminalChannel(s) already closed it.
+		relay.close()
 	}
-	return ch, cleanup
+	return relay.ch, cleanup
 }
 
 // DeliverTerminalFrame routes a decoded frame payload to the channel registered
 // for sessionID. Returns false if no relay is registered for that session.
 func (a *ConnectedAgent) DeliverTerminalFrame(sessionID uuid.UUID, payload []byte) bool {
 	a.terminalMu.Lock()
-	ch, ok := a.terminalChannels[sessionID]
+	relay, ok := a.terminalChannels[sessionID]
 	a.terminalMu.Unlock()
 
 	if !ok {
 		return false
 	}
+	ch := relay.ch
 
 	// Copy payload so the caller's buffer can be reused.
 	buf := make([]byte, len(payload))
@@ -164,8 +177,8 @@ func (a *ConnectedAgent) DeliverTerminalFrame(sessionID uuid.UUID, payload []byt
 func (a *ConnectedAgent) CloseTerminalChannel(sessionID uuid.UUID) {
 	a.terminalMu.Lock()
 	defer a.terminalMu.Unlock()
-	if ch, ok := a.terminalChannels[sessionID]; ok {
-		close(ch)
+	if relay, ok := a.terminalChannels[sessionID]; ok {
+		relay.close()
 		delete(a.terminalChannels, sessionID)
 	}
 }
@@ -177,8 +190,8 @@ func (a *ConnectedAgent) CloseTerminalChannels() {
 	a.terminalMu.Lock()
 	defer a.terminalMu.Unlock()
 
-	for id, ch := range a.terminalChannels {
-		close(ch)
+	for id, relay := range a.terminalChannels {
+		relay.close()
 		delete(a.terminalChannels, id)
 	}
 }

--- a/services/agent-hub/internal/hub/agent_test.go
+++ b/services/agent-hub/internal/hub/agent_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -83,5 +84,73 @@ func TestTerminalRelayCloseIsIdempotent(t *testing.T) {
 	cleanupC() // must not panic
 	if _, open := <-chC; open {
 		t.Fatal("expected chC closed after CloseTerminalChannel")
+	}
+}
+
+// TestDeliverTerminalFrame_NoRaceWithClose hammers DeliverTerminalFrame from
+// one goroutine while another goroutine concurrently registers, cleans up,
+// and bulk-closes relays for the same session. Sends and closes are
+// serialized by terminalMu, so this must never panic with
+// "send on closed channel". Run under -race.
+func TestDeliverTerminalFrame_NoRaceWithClose(t *testing.T) {
+	sessionUUID := uuid.New()
+	a := &ConnectedAgent{
+		terminalChannels: make(map[uuid.UUID]*terminalRelay),
+	}
+
+	const iterations = 2000
+	payload := []byte("frame")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Sender: deliver frames as fast as possible.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			a.DeliverTerminalFrame(sessionUUID, payload)
+		}
+	}()
+
+	// Closer: churn registrations and closes for the same session, cycling
+	// through every close path (cleanup, CloseTerminalChannel,
+	// CloseTerminalChannels).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			ch, cleanup := a.RegisterTerminalRelay(sessionUUID)
+			switch i % 3 {
+			case 0:
+				cleanup()
+			case 1:
+				a.CloseTerminalChannel(sessionUUID)
+				cleanup()
+			case 2:
+				a.CloseTerminalChannels()
+				cleanup()
+			}
+			// Drain so a closed, non-empty channel is observed as closed.
+			for range ch {
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out: goroutines did not finish (deadlock?)")
+	}
+
+	a.terminalMu.Lock()
+	n := len(a.terminalChannels)
+	a.terminalMu.Unlock()
+	if n != 0 {
+		t.Errorf("expected no relays left registered, got %d", n)
 	}
 }

--- a/services/agent-hub/internal/hub/agent_test.go
+++ b/services/agent-hub/internal/hub/agent_test.go
@@ -11,7 +11,7 @@ func TestRegisterTerminalRelay_StaleCleanupDoesNotClobberLiveRegistration(t *tes
 	sessionUUID := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
 
 	a := &ConnectedAgent{
-		terminalChannels: make(map[uuid.UUID]chan []byte),
+		terminalChannels: make(map[uuid.UUID]*terminalRelay),
 	}
 
 	// First registration (stale).
@@ -46,5 +46,42 @@ func TestRegisterTerminalRelay_StaleCleanupDoesNotClobberLiveRegistration(t *tes
 
 	if ok := a.DeliverTerminalFrame(sessionUUID, payload); ok {
 		t.Fatal("DeliverTerminalFrame returned true after cleanup2(): channel should be gone")
+	}
+}
+
+// TestTerminalRelayCloseIsIdempotent verifies that a relay torn down by the
+// hub (CloseTerminalChannels on disconnect, or CloseTerminalChannel on a
+// relay-end frame) can still be cleaned up by its owner without a
+// double-close panic, and vice versa.
+func TestTerminalRelayCloseIsIdempotent(t *testing.T) {
+	a := &ConnectedAgent{
+		Name:             "test",
+		terminalChannels: make(map[uuid.UUID]*terminalRelay),
+	}
+
+	sessA := uuid.New()
+	chA, cleanupA := a.RegisterTerminalRelay(sessA)
+	a.CloseTerminalChannels()
+	if _, open := <-chA; open {
+		t.Fatal("expected chA closed after CloseTerminalChannels")
+	}
+	cleanupA() // must not panic
+	cleanupA() // still must not panic
+
+	sessB := uuid.New()
+	chB, cleanupB := a.RegisterTerminalRelay(sessB)
+	cleanupB()
+	a.CloseTerminalChannel(sessB) // already removed; no-op
+	a.CloseTerminalChannels()     // must not panic
+	if _, open := <-chB; open {
+		t.Fatal("expected chB closed after cleanupB")
+	}
+
+	sessC := uuid.New()
+	chC, cleanupC := a.RegisterTerminalRelay(sessC)
+	a.CloseTerminalChannel(sessC)
+	cleanupC() // must not panic
+	if _, open := <-chC; open {
+		t.Fatal("expected chC closed after CloseTerminalChannel")
 	}
 }

--- a/services/agent-hub/internal/hub/hub.go
+++ b/services/agent-hub/internal/hub/hub.go
@@ -24,19 +24,27 @@ var ErrAdvertiseAddressChanged = errors.New("advertise address changed on re-reg
 // count; business-logic errors (e.g. rpcErrNotFound) do not.
 const maxConsecutiveRPCFailures = 3
 
-// MaxMessageSize is the maximum allowed WebSocket message size for relay
-// (binary) frames (1 MiB). Sized for PTY burst output from terminal relay.
-// This is the connection-level read limit applied via SetReadLimit.
-const MaxMessageSize = 1 << 20
+// AgentMaxMessageSize is the hub's read limit for a single WebSocket message
+// on the agent connection (both JSON-RPC text frames and binary relay
+// frames). It re-exports sharedrelay.AgentMaxMessageSize so both sides of the
+// link are compiled against the same number.
+//
+// This is a bug backstop against runaway allocation, not a protocol
+// constraint: every legitimate message is bounded by construction far below
+// this value (sharedrelay.MaxSnapshotFrameSize for relay frames, a
+// metadata-only listSessions for RPC). Never tune it downward to "catch"
+// oversized payloads — exceeding it closes the agent connection, which is the
+// worst possible response to a payload bug. Message size must never be a
+// reason to mark an agent offline (issue #685).
+const AgentMaxMessageSize = sharedrelay.AgentMaxMessageSize
 
-// RPCMaxMessageSize is the maximum allowed size for a single JSON-RPC
-// (text) frame from an agent (512 KiB). listSessions responses carry
-// prompt_context, which is derived from PTY scrollback: TUI agents redraw
-// with cursor movement rather than newlines, so "15 lines" of context can
-// span hundreds of KiB and a 64 KiB cap disconnected agents in a reconnect
-// loop. Must stay below MaxMessageSize so oversized text frames reach the
-// post-read check in HandleAgentConnection instead of dying at SetReadLimit.
-const RPCMaxMessageSize = 512 * 1024
+// BrowserMaxMessageSize bounds a single WebSocket message read from a browser
+// (or legacy ttyd) terminal connection: keystrokes, resize messages and small
+// control frames. It is a separate link from the agent connection and is
+// deliberately much smaller than AgentMaxMessageSize. It only governs reads;
+// hub→browser writes (relay payloads up to sharedrelay.MaxSnapshotFrameSize)
+// are not subject to SetReadLimit.
+const BrowserMaxMessageSize = 1 << 20
 
 // Hub manages registered agentd connections.
 type Hub struct {
@@ -317,7 +325,7 @@ func (h *Hub) Call(ctx context.Context, agent *ConnectedAgent, method string, pa
 // Text frames are dispatched as JSON-RPC responses; binary frames are decoded
 // as terminal relay frames and delivered to the registered session channel.
 func (h *Hub) HandleAgentConnection(ctx context.Context, agent *ConnectedAgent) {
-	agent.Conn().SetReadLimit(MaxMessageSize)
+	agent.Conn().SetReadLimit(AgentMaxMessageSize)
 
 	go h.heartbeatLoop(ctx, agent)
 	go h.wsKeepaliveLoop(ctx, agent)
@@ -362,17 +370,9 @@ func (h *Hub) HandleAgentConnection(ctx context.Context, agent *ConnectedAgent) 
 			}
 
 		case websocket.MessageText:
-			if len(data) > RPCMaxMessageSize {
-				slog.Warn("oversized RPC frame from agent, closing connection",
-					"agent", agent.Name,
-					"size", len(data),
-					"limit", RPCMaxMessageSize,
-				)
-				agent.Conn().Close(websocket.StatusMessageTooBig, "RPC frame exceeds limit")
-				agent.CloseTerminalChannels()
-				h.markOfflineIfCurrent(agent.Name, agent)
-				return
-			}
+			// Message size is never a reason to close the connection or mark
+			// the agent offline (issue #685); the only size bound is the
+			// AgentMaxMessageSize read backstop applied above.
 			var msg Response
 			if err := json.Unmarshal(data, &msg); err != nil {
 				slog.Warn("invalid message from agent", "agent", agent.Name, "error", err)

--- a/services/agent-hub/internal/hub/hub_test.go
+++ b/services/agent-hub/internal/hub/hub_test.go
@@ -737,7 +737,6 @@ func TestAgentCount(t *testing.T) {
 	}
 }
 
-
 // TestRegister_RejectChangedAdvertiseAddress verifies that Hub.Register rejects
 // re-registration when the AdvertiseAddress differs from the original.
 // The first agent is registered via a real WebSocket connection (using
@@ -918,9 +917,13 @@ func connectRawAgent(t *testing.T, url, name string) *websocket.Conn {
 	return conn
 }
 
-// TestHandleAgentConnection_OversizedTextFrame verifies that a text frame
-// larger than RPCMaxMessageSize causes the hub to close the connection and
-// mark the agent offline.
+// TestHandleAgentConnection_OversizedTextFrame verifies that a large text
+// (JSON-RPC) frame does NOT cause the hub to close the connection or mark
+// the agent offline. Per issue #685, message size alone must never be
+// treated as a dead-peer signal — only the connection-level read limit
+// backstop may close the connection, and no legitimate RPC message should
+// ever approach it. This uses a 600 KiB frame, comfortably larger than the
+// old (deleted) RPC size check but far below the hub's read limit.
 func TestHandleAgentConnection_OversizedTextFrame(t *testing.T) {
 	h, url := startTestHub(t)
 
@@ -932,41 +935,134 @@ func TestHandleAgentConnection_OversizedTextFrame(t *testing.T) {
 		t.Fatalf("expected agent to start online, got %s", agent.Status())
 	}
 
-	// Send a text frame one byte larger than RPCMaxMessageSize.
-	oversized := make([]byte, RPCMaxMessageSize+1)
-	for i := range oversized {
-		oversized[i] = 'x'
+	// Build a 600 KiB JSON-RPC-shaped text frame (padding embedded in the
+	// result field). This is larger than the old, now-deleted
+	// 512 KiB post-read RPC frame cap but must be handled without closing the
+	// connection.
+	const frameSize = 600 * 1024
+	const prefix = `{"jsonrpc":"2.0","id":"x","result":"`
+	const suffix = `"}`
+	padding := make([]byte, frameSize-len(prefix)-len(suffix))
+	for i := range padding {
+		padding[i] = 'x'
 	}
-	// Write may succeed (the close may happen on the hub side during Read).
-	_ = conn.Write(context.Background(), websocket.MessageText, oversized)
+	oversized := append([]byte(prefix), padding...)
+	oversized = append(oversized, []byte(suffix)...)
 
-	// The next Read on the client side should fail — the hub closed the
-	// connection after detecting the oversized text frame.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	_, _, readErr := conn.Read(ctx)
-	if readErr == nil {
-		t.Fatal("expected connection to be closed by hub after oversized text frame")
+	if err := conn.Write(context.Background(), websocket.MessageText, oversized); err != nil {
+		t.Fatalf("write large text frame: %v", err)
 	}
 
-	// Poll until the hub marks the agent offline.
-	deadline := time.Now().Add(2 * time.Second)
+	// On current (buggy) code the hub closes the connection synchronously in
+	// the oversized-frame branch, but websocket.Conn.Close can take several
+	// seconds to complete its handshake before markOfflineIfCurrent runs. A
+	// short sleep would let this test pass for the wrong reason (checking
+	// before the offline transition happens), so poll for several seconds
+	// and fail the instant the agent goes offline.
+	deadline := time.Now().Add(6 * time.Second)
 	for time.Now().Before(deadline) {
-		if agent.Status() == StatusOffline {
-			break
+		if agent.Status() != StatusOnline {
+			t.Fatalf("agent went offline after large text frame (status=%s) — message size must never mark an agent offline", agent.Status())
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
-	if agent.Status() != StatusOffline {
-		t.Errorf("expected agent to be marked offline after oversized text frame, got %s", agent.Status())
+
+	if agent.Status() != StatusOnline {
+		t.Errorf("expected agent to remain online after large text frame, got %s", agent.Status())
+	}
+
+	// Confirm the connection is still usable.
+	pingReq, _ := NewRequest("ping-check", "ping", nil)
+	pingData, _ := json.Marshal(pingReq)
+	if err := conn.Write(context.Background(), websocket.MessageText, pingData); err != nil {
+		t.Fatalf("write after large text frame failed — connection was closed: %v", err)
 	}
 }
 
-// TestHandleAgentConnection_AtLimitBinaryFrame verifies that a binary relay
-// frame does NOT close the connection. Binary frames are allowed up to
-// MaxMessageSize (1 MiB); the hub logs a warning about the invalid frame
-// header and continues the read loop. The RPC size check must not apply
-// to binary frames.
+// TestHandleAgentConnection_FullBufferSnapshotFrame verifies that a binary
+// relay frame carrying a full PTY ring-buffer snapshot replay (the exact
+// scenario that caused the 2026-08-23 outage in issue #685) does not close
+// the agent connection or mark the agent offline, and that the frame is
+// delivered intact to the registered terminal relay channel.
+//
+// Frame size is exactly sharedrelay.MaxSnapshotFrameSize (1,048,593 bytes):
+// ring buffer (1<<20 - 1) + ttyd '0' prefix (1) + relay header (17). The
+// hub's former agent-connection read limit (1<<20 = 1,048,576) was 17 bytes
+// too small for this frame, so coder/websocket closed the connection with
+// StatusMessageTooBig before HandleAgentConnection ever saw the data.
+func TestHandleAgentConnection_FullBufferSnapshotFrame(t *testing.T) {
+	h, url := startTestHub(t)
+
+	conn := connectRawAgent(t, url, "snapshot-agent")
+	defer conn.CloseNow()
+
+	agent := waitForAgent(t, h, "snapshot-agent")
+	if agent.Status() != StatusOnline {
+		t.Fatalf("expected agent to start online, got %s", agent.Status())
+	}
+
+	sessionID := uuid.New()
+	relayCh, cleanup, err := h.OpenTerminalRelay(context.Background(), "snapshot-agent", sessionID)
+	if err != nil {
+		t.Fatalf("OpenTerminalRelay: %v", err)
+	}
+	// On current (buggy) code the hub closes the agent connection and calls
+	// CloseTerminalChannels internally, which already closes this relay
+	// channel. Guard against a double-close panic from our own cleanup call
+	// so the test reports the real failure (frame not delivered / agent
+	// offline) instead of crashing the test binary.
+	defer func() {
+		defer func() { _ = recover() }()
+		cleanup()
+	}()
+
+	// Build the ttyd-prefixed payload: '0' output-type byte + ring buffer
+	// worth of PTY output.
+	ttydPayload := make([]byte, sharedrelay.MaxPTYBufferSize+sharedrelay.TtydFramePrefixLen)
+	ttydPayload[0] = '0'
+	for i := sharedrelay.TtydFramePrefixLen; i < len(ttydPayload); i++ {
+		ttydPayload[i] = byte('a' + i%26)
+	}
+	if len(ttydPayload) != sharedrelay.MaxSnapshotFrameSize-sharedrelay.TerminalFrameHeaderLen {
+		t.Fatalf("test setup: unexpected ttyd payload length %d", len(ttydPayload))
+	}
+
+	frame := EncodeTerminalFrame(sessionID, ttydPayload)
+	if len(frame) != sharedrelay.MaxSnapshotFrameSize {
+		t.Fatalf("test setup: expected frame of %d bytes, got %d", sharedrelay.MaxSnapshotFrameSize, len(frame))
+	}
+
+	if err := conn.Write(context.Background(), websocket.MessageBinary, frame); err != nil {
+		t.Fatalf("write full-buffer snapshot frame: %v", err)
+	}
+
+	// The frame should be delivered intact to the relay channel.
+	select {
+	case delivered := <-relayCh:
+		if len(delivered) != len(ttydPayload) {
+			t.Errorf("expected delivered payload of %d bytes, got %d", len(ttydPayload), len(delivered))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for full-buffer snapshot frame to be delivered — connection likely closed by SetReadLimit")
+	}
+
+	// Give the hub's read loop a moment; the connection must still be open.
+	time.Sleep(100 * time.Millisecond)
+	if agent.Status() != StatusOnline {
+		t.Errorf("expected agent to remain online after full-buffer snapshot frame, got %s", agent.Status())
+	}
+
+	// Confirm the connection is still usable for further frames.
+	pingReq, _ := NewRequest("ping-check", "ping", nil)
+	pingData, _ := json.Marshal(pingReq)
+	if err := conn.Write(context.Background(), websocket.MessageText, pingData); err != nil {
+		t.Fatalf("write after snapshot frame failed — connection was closed: %v", err)
+	}
+}
+
+// TestHandleAgentConnection_AtLimitBinaryFrame verifies that a large binary
+// relay frame with an invalid header does NOT close the connection: the hub
+// logs a warning about the invalid frame and continues the read loop.
 func TestHandleAgentConnection_AtLimitBinaryFrame(t *testing.T) {
 	h, url := startTestHub(t)
 
@@ -978,12 +1074,11 @@ func TestHandleAgentConnection_AtLimitBinaryFrame(t *testing.T) {
 		t.Fatalf("expected agent to start online, got %s", agent.Status())
 	}
 
-	// Send a binary frame of exactly MaxMessageSize bytes. The frame header
-	// will be invalid (no 0x01 type byte in the right position), so
+	// Send a half-snapshot-sized binary frame. The frame header will be
+	// invalid (no 0x01 type byte in the right position), so
 	// DecodeTerminalFrame returns an error — but the hub logs a warning and
 	// continues the loop without closing the connection.
-	// Use half the relay limit to avoid any boundary behavior from WebSocket framing overhead.
-	atLimit := make([]byte, MaxMessageSize/2)
+	atLimit := make([]byte, sharedrelay.MaxSnapshotFrameSize/2)
 	if err := conn.Write(context.Background(), websocket.MessageBinary, atLimit); err != nil {
 		t.Fatalf("write binary frame: %v", err)
 	}
@@ -1008,13 +1103,16 @@ func TestHandleAgentConnection_AtLimitBinaryFrame(t *testing.T) {
 	}
 }
 
-// TestMaxMessageSizeConstants asserts that RPCMaxMessageSize is strictly less
-// than MaxMessageSize. If someone changes one constant without the other this
-// test will fail, preventing an accidental inversion.
+// TestMaxMessageSizeConstants asserts the invariant that protects against
+// issue #685: the largest legitimate relay frame the hub can receive
+// (sharedrelay.MaxSnapshotFrameSize, a full PTY ring-buffer snapshot replay)
+// must be strictly less than the hub's agent-connection read limit. If this
+// inversion ever creeps back in, coder/websocket closes the whole agent
+// connection on a routine snapshot replay instead of delivering the frame.
 func TestMaxMessageSizeConstants(t *testing.T) {
-	if RPCMaxMessageSize >= MaxMessageSize {
-		t.Errorf("RPCMaxMessageSize (%d) must be < MaxMessageSize (%d)",
-			RPCMaxMessageSize, MaxMessageSize)
+	if sharedrelay.MaxSnapshotFrameSize >= AgentMaxMessageSize {
+		t.Errorf("sharedrelay.MaxSnapshotFrameSize (%d) must be < AgentMaxMessageSize (%d) — a full ring-buffer snapshot replay would close the agent connection (issue #685)",
+			sharedrelay.MaxSnapshotFrameSize, AgentMaxMessageSize)
 	}
 }
 
@@ -1025,7 +1123,7 @@ func TestCloseTerminalChannel(t *testing.T) {
 		Name:             "test-agent",
 		status:           StatusOnline,
 		pending:          make(map[string]chan *Response),
-		terminalChannels: make(map[uuid.UUID]chan []byte),
+		terminalChannels: make(map[uuid.UUID]*terminalRelay),
 	}
 
 	sessA := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")

--- a/services/agent-hub/internal/hub/hub_test.go
+++ b/services/agent-hub/internal/hub/hub_test.go
@@ -953,29 +953,67 @@ func TestHandleAgentConnection_OversizedTextFrame(t *testing.T) {
 		t.Fatalf("write large text frame: %v", err)
 	}
 
-	// On current (buggy) code the hub closes the connection synchronously in
-	// the oversized-frame branch, but websocket.Conn.Close can take several
-	// seconds to complete its handshake before markOfflineIfCurrent runs. A
-	// short sleep would let this test pass for the wrong reason (checking
-	// before the offline transition happens), so poll for several seconds
-	// and fail the instant the agent goes offline.
-	deadline := time.Now().Add(6 * time.Second)
+	// Deterministic liveness proof: perform a real hub->agent RPC round-trip
+	// over the same connection AFTER the large frame was read by the hub.
+	// The hub processes frames sequentially in its read loop, so if the
+	// large frame had caused the hub to close the connection (the old
+	// size-based close), the ping request below would never reach the raw
+	// agent and h.Call would fail with a timeout or write error. This is
+	// strictly stronger than polling Status() for a fixed interval, and
+	// completes in milliseconds on the happy path.
+	//
+	// The raw agent replies to every request it receives (including any
+	// heartbeat ping) so the round-trip cannot be confused by other traffic.
+	readErr := make(chan error, 1)
+	go func() {
+		for {
+			_, data, err := conn.Read(context.Background())
+			if err != nil {
+				readErr <- err
+				return
+			}
+			var req Request
+			if err := json.Unmarshal(data, &req); err != nil || req.Method == "" {
+				continue
+			}
+			result, _ := json.Marshal(map[string]string{"pong": "ok"})
+			resp := &Response{JSONRPC: "2.0", ID: req.ID, Result: result}
+			respData, _ := json.Marshal(resp)
+			if err := conn.Write(context.Background(), websocket.MessageText, respData); err != nil {
+				readErr <- err
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := h.Call(ctx, agent, "ping", nil)
+	if err != nil {
+		select {
+		case rerr := <-readErr:
+			t.Fatalf("RPC round-trip after large text frame failed (%v); agent-side read error: %v — hub closed the connection on message size", err, rerr)
+		default:
+			t.Fatalf("RPC round-trip after large text frame failed: %v — hub closed or stalled the connection on message size", err)
+		}
+	}
+	var pong map[string]string
+	if err := json.Unmarshal(result, &pong); err != nil || pong["pong"] != "ok" {
+		t.Fatalf("unexpected ping result after large text frame: %s", result)
+	}
+
+	// Belt-and-braces: the agent must still be online. The round-trip above
+	// already proves the connection is open, so a short poll suffices to
+	// catch a delayed offline transition.
+	deadline := time.Now().Add(300 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if agent.Status() != StatusOnline {
 			t.Fatalf("agent went offline after large text frame (status=%s) — message size must never mark an agent offline", agent.Status())
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(25 * time.Millisecond)
 	}
-
 	if agent.Status() != StatusOnline {
 		t.Errorf("expected agent to remain online after large text frame, got %s", agent.Status())
-	}
-
-	// Confirm the connection is still usable.
-	pingReq, _ := NewRequest("ping-check", "ping", nil)
-	pingData, _ := json.Marshal(pingReq)
-	if err := conn.Write(context.Background(), websocket.MessageText, pingData); err != nil {
-		t.Fatalf("write after large text frame failed — connection was closed: %v", err)
 	}
 }
 

--- a/services/agent-hub/internal/hub/messages.go
+++ b/services/agent-hub/internal/hub/messages.go
@@ -28,9 +28,9 @@ type RPCError struct {
 
 // RegisterParams is sent by agentd when it connects.
 type RegisterParams struct {
-	Name     string                    `json:"name"`
-	Profiles map[string]ProfileInfo    `json:"profiles"`
-	Ttyd     TtydInfo                  `json:"ttyd"`
+	Name     string                 `json:"name"`
+	Profiles map[string]ProfileInfo `json:"profiles"`
+	Ttyd     TtydInfo               `json:"ttyd"`
 }
 
 // ProfileInfo describes an agent profile.
@@ -53,6 +53,10 @@ type TtydInfo struct {
 // RegisterResult is returned by the hub to acknowledge registration.
 type RegisterResult struct {
 	Accepted bool `json:"accepted"`
+	// MaxMessageBytes advertises the hub's agent-connection read limit
+	// (AgentMaxMessageSize) so agentd can size outgoing messages against the
+	// hub it is actually talking to instead of a compiled-in constant.
+	MaxMessageBytes int64 `json:"max_message_bytes,omitempty"`
 }
 
 // PongResult is returned by agentd in response to a ping.

--- a/services/agent-hub/internal/hub/relay_test.go
+++ b/services/agent-hub/internal/hub/relay_test.go
@@ -60,7 +60,8 @@ func TestDecodeTerminalFrame_WrongTypeByte(t *testing.T) {
 	// Build a valid-length frame but with a wrong type byte.
 	frame := make([]byte, sharedrelay.TerminalFrameHeaderLen+4)
 	frame[0] = 0x02 // wrong type
-	id := uuid.New(); copy(frame[1:17], id[:])
+	id := uuid.New()
+	copy(frame[1:17], id[:])
 	copy(frame[17:], []byte("data"))
 
 	_, _, err := DecodeTerminalFrame(frame)

--- a/services/agent-hub/internal/proxy/terminal.go
+++ b/services/agent-hub/internal/proxy/terminal.go
@@ -121,7 +121,10 @@ func handleTerminalProxy(h *hub.Hub, allowedOrigins []string, pingInterval time.
 				return
 			}
 
-			browserConn.SetReadLimit(hub.MaxMessageSize)
+			// Browser→hub input frames (keystrokes, resize) are small; this
+			// bounds reads only. Relay payloads flowing hub→browser are writes
+			// and are not subject to this limit.
+			browserConn.SetReadLimit(hub.BrowserMaxMessageSize)
 
 			// Set up idle timeout if configured.
 			var idleTimer *time.Timer
@@ -301,9 +304,10 @@ func handleTerminalProxy(h *hub.Hub, allowedOrigins []string, pingInterval time.
 			return
 		}
 
-		// Apply read limits to prevent memory exhaustion.
-		browserConn.SetReadLimit(hub.MaxMessageSize)
-		ttydConn.SetReadLimit(hub.MaxMessageSize)
+		// Apply read limits to prevent memory exhaustion. These are the
+		// browser and legacy-ttyd links, not the agent connection.
+		browserConn.SetReadLimit(hub.BrowserMaxMessageSize)
+		ttydConn.SetReadLimit(hub.BrowserMaxMessageSize)
 
 		// Set up idle timeout if configured.
 		var idleTimer *time.Timer

--- a/services/agent-hub/internal/rest/handlers.go
+++ b/services/agent-hub/internal/rest/handlers.go
@@ -274,9 +274,9 @@ func handleCreateSession(h *hub.Hub) http.HandlerFunc {
 			return
 		}
 
-		// CreateSession params are small (session ID + profile name); cap at RPC
-		// frame limit rather than the global REST body limit (1 MiB).
-		r.Body = http.MaxBytesReader(w, r.Body, hub.RPCMaxMessageSize)
+		// CreateSession params are small (session ID + profile name); cap
+		// tighter than the global REST body limit (1 MiB).
+		r.Body = http.MaxBytesReader(w, r.Body, MaxSessionRequestBodySize)
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -361,7 +361,7 @@ func handleSendInput(h *hub.Hub) http.HandlerFunc {
 
 		sessionID := r.PathValue("id")
 
-		r.Body = http.MaxBytesReader(w, r.Body, hub.RPCMaxMessageSize)
+		r.Body = http.MaxBytesReader(w, r.Body, MaxSessionRequestBodySize)
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -683,9 +683,10 @@ func handleAgentWebSocket(h *hub.Hub, agentToken string) http.HandlerFunc {
 			return
 		}
 
-		// The register message is a JSON-RPC text frame; apply the RPC limit.
-		// HandleAgentConnection raises this to MaxMessageSize for relay frames.
-		conn.SetReadLimit(hub.RPCMaxMessageSize)
+		// Apply the agent-link read backstop before the first read. This is
+		// the same limit HandleAgentConnection uses for the connection's
+		// lifetime; message size is never a reason to drop an agent.
+		conn.SetReadLimit(hub.AgentMaxMessageSize)
 
 		// Read the first message, which must be a register request.
 		_, data, err := conn.Read(r.Context())
@@ -741,7 +742,10 @@ func handleAgentWebSocket(h *hub.Hub, agentToken string) http.HandlerFunc {
 			slog.Warn("agent registration rejected", "agent", params.Name, "error", regErr)
 			resp = hub.NewErrorResponse(req.ID, hub.RPCErrFailedPrecondition, "registration rejected")
 		} else {
-			resp, err = hub.NewResponse(req.ID, &hub.RegisterResult{Accepted: true})
+			resp, err = hub.NewResponse(req.ID, &hub.RegisterResult{
+				Accepted:        true,
+				MaxMessageBytes: hub.AgentMaxMessageSize,
+			})
 			if err != nil {
 				slog.Error("failed to create register response", "error", err)
 				conn.Close(websocket.StatusInternalError, "internal error")

--- a/services/agent-hub/internal/rest/handlers_test.go
+++ b/services/agent-hub/internal/rest/handlers_test.go
@@ -161,7 +161,6 @@ func TestFilterAgentsByRepo(t *testing.T) {
 		}
 	})
 
-
 	t.Run("non-GitHub HTTPS host matches full URL", func(t *testing.T) {
 		gitlabAgents := []hub.AgentInfo{
 			{
@@ -370,7 +369,7 @@ func TestHandleSendInput_BodyTooLargeReturns413(t *testing.T) {
 
 	handler := handleSendInput(h)
 
-	oversizedBody := strings.Repeat("x", hub.RPCMaxMessageSize+1)
+	oversizedBody := strings.Repeat("x", MaxSessionRequestBodySize+1)
 	req := httptest.NewRequest("POST", "/api/v1/agents/big-body-agent/sessions/sess-1/input", strings.NewReader(oversizedBody))
 	req.SetPathValue("name", "big-body-agent")
 	req.SetPathValue("id", "sess-1")
@@ -538,5 +537,66 @@ func TestProfileName_ExposedInGetAgent(t *testing.T) {
 	}
 	if profile.Name != "Named Get Profile" {
 		t.Errorf("expected profile Name %q, got %q", "Named Get Profile", profile.Name)
+	}
+}
+
+// TestHandleAgentWebSocket_RegisterAdvertisesMaxMessageBytes verifies that
+// the register acknowledgment carries max_message_bytes equal to the hub's
+// agent-connection read backstop, so agentd can size outgoing messages
+// against the hub it is actually talking to (issue #685, Layer 2).
+func TestHandleAgentWebSocket_RegisterAdvertisesMaxMessageBytes(t *testing.T) {
+	h := hub.New(30*time.Second, 5*time.Second, 0, 5*time.Minute, 0)
+	h.Start()
+	t.Cleanup(h.Stop)
+
+	agentToken := "test-agent-token"
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ws/agent", handleAgentWebSocket(h, agentToken))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/agent"
+	conn, _, err := websocket.Dial(context.Background(), wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": {"Bearer " + agentToken}},
+	})
+	if err != nil {
+		t.Fatalf("dial agent ws: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(websocket.StatusNormalClosure, "test done") })
+
+	regReq, _ := hub.NewRequest("reg-1", "register", &hub.RegisterParams{
+		Name: "limit-agent",
+		Profiles: map[string]hub.ProfileInfo{
+			"default": {Description: "test", Repo: "https://github.com/test/repo"},
+		},
+	})
+	data, _ := json.Marshal(regReq)
+	if err := conn.Write(context.Background(), websocket.MessageText, data); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	_, ack, err := conn.Read(context.Background())
+	if err != nil {
+		t.Fatalf("read register ack: %v", err)
+	}
+
+	// Decode the raw wire JSON rather than hub.RegisterResult so a renamed or
+	// dropped json tag is caught.
+	var resp struct {
+		Result struct {
+			Accepted        bool   `json:"accepted"`
+			MaxMessageBytes *int64 `json:"max_message_bytes"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(ack, &resp); err != nil {
+		t.Fatalf("unmarshal register ack %s: %v", ack, err)
+	}
+	if !resp.Result.Accepted {
+		t.Fatalf("expected accepted=true in register ack: %s", ack)
+	}
+	if resp.Result.MaxMessageBytes == nil {
+		t.Fatalf("register ack missing max_message_bytes: %s", ack)
+	}
+	if got := *resp.Result.MaxMessageBytes; got != hub.AgentMaxMessageSize {
+		t.Errorf("max_message_bytes = %d, want hub.AgentMaxMessageSize (%d)", got, hub.AgentMaxMessageSize)
 	}
 }

--- a/services/agent-hub/internal/rest/integration_test.go
+++ b/services/agent-hub/internal/rest/integration_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/dokipen/claude-cadence/services/agent-hub/internal/config"
 	"github.com/dokipen/claude-cadence/services/agent-hub/internal/hub"
 	"github.com/dokipen/claude-cadence/services/agent-hub/internal/rest"
+	sharedrelay "github.com/dokipen/claude-cadence/services/shared/relay"
+	"github.com/google/uuid"
 )
 
 // testConfig returns a minimal config for integration tests.
@@ -743,9 +745,9 @@ func TestIntegration_OversizedBody(t *testing.T) {
 	simulateAgent(t, baseURL, agentToken, "test-agent")
 	waitForAgent(t, h, "test-agent")
 
-	// handleCreateSession caps the body at RPCMaxMessageSize (64 KiB), tighter
-	// than the global REST limit. Build a body that exceeds it by 1 byte.
-	oversizedBody := strings.NewReader(strings.Repeat("x", hub.RPCMaxMessageSize+1))
+	// handleCreateSession caps the body at rest.MaxSessionRequestBodySize,
+	// tighter than the global REST limit. Build a body that exceeds it by 1 byte.
+	oversizedBody := strings.NewReader(strings.Repeat("x", rest.MaxSessionRequestBodySize+1))
 
 	req, _ := http.NewRequest("POST", baseURL+"/api/v1/agents/test-agent/sessions", oversizedBody)
 	req.Header.Set("Authorization", "Bearer "+apiToken)
@@ -1132,5 +1134,189 @@ func TestIntegration_RejectInvalidProfileType(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&agentsBody)
 	if len(agentsBody["agents"]) != 0 {
 		t.Fatalf("expected 0 agents after invalid type rejection, got %d", len(agentsBody["agents"]))
+	}
+}
+
+// simulateAgentWithLargeListSessions connects a fake agent whose listSessions
+// reply is a JSON document of roughly payloadSize bytes. It returns the agent
+// connection so the test can also push relay frames through it.
+func simulateAgentWithLargeListSessions(t *testing.T, baseURL, agentToken, name string, payloadSize int) *websocket.Conn {
+	t.Helper()
+
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/ws/agent"
+	ctx := context.Background()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": {"Bearer " + agentToken},
+		},
+	})
+	if err != nil {
+		t.Fatalf("dial hub: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(websocket.StatusNormalClosure, "test done") })
+
+	regReq, _ := hub.NewRequest("reg-1", "register", &hub.RegisterParams{
+		Name: name,
+		Profiles: map[string]hub.ProfileInfo{
+			"default": {Description: "test profile", Repo: "https://github.com/test/repo"},
+		},
+	})
+	data, _ := json.Marshal(regReq)
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	_, ack, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read register ack: %v", err)
+	}
+	var ackResp struct {
+		Result hub.RegisterResult `json:"result"`
+	}
+	if err := json.Unmarshal(ack, &ackResp); err != nil {
+		t.Fatalf("unmarshal register ack: %v", err)
+	}
+	if ackResp.Result.MaxMessageBytes != hub.AgentMaxMessageSize {
+		t.Fatalf("register ack max_message_bytes = %d, want %d", ackResp.Result.MaxMessageBytes, hub.AgentMaxMessageSize)
+	}
+
+	// Pre-build the oversized listSessions result: a sessions array whose
+	// single entry carries a prompt_context blob of the requested size.
+	padding := strings.Repeat("x", payloadSize)
+	largeResult, _ := json.Marshal(map[string]any{
+		"sessions": []map[string]any{{
+			"id":             "sess-1",
+			"prompt_context": padding,
+		}},
+	})
+
+	go func() {
+		for {
+			_, data, err := conn.Read(context.Background())
+			if err != nil {
+				return
+			}
+			var req hub.Request
+			json.Unmarshal(data, &req)
+
+			var respData []byte
+			switch req.Method {
+			case "listSessions":
+				resp := &hub.Response{JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(largeResult)}
+				respData, _ = json.Marshal(resp)
+			case "ping":
+				resp, _ := hub.NewResponse(req.ID, map[string]bool{"pong": true})
+				respData, _ = json.Marshal(resp)
+			default:
+				resp, _ := hub.NewResponse(req.ID, map[string]string{"echo": req.Method})
+				respData, _ = json.Marshal(resp)
+			}
+			conn.Write(context.Background(), websocket.MessageText, respData)
+		}
+	}()
+
+	return conn
+}
+
+// TestIntegration_MultiMiBListSessionsKeepsAgentOnline verifies Layer 1 of
+// issue #685: a multi-MiB listSessions reply (well above the old 512 KiB RPC
+// cap, well below the 16 MiB read backstop) is delivered to the REST caller
+// unchanged, and the agent is neither closed nor marked offline. A terminal
+// relay registered before the call must still be open and deliverable
+// afterwards — previously the oversized-frame path closed every relay.
+func TestIntegration_MultiMiBListSessionsKeepsAgentOnline(t *testing.T) {
+	const payloadSize = 3 << 20 // 3 MiB
+	if payloadSize >= sharedrelay.AgentMaxMessageSize {
+		t.Fatalf("test setup: payload %d must be under the backstop %d", payloadSize, sharedrelay.AgentMaxMessageSize)
+	}
+
+	apiToken := "test-api-token"
+	agentToken := "test-agent-token"
+	cfg := testConfig(apiToken, agentToken)
+
+	h, baseURL := startIntegrationServer(t, cfg)
+	agentConn := simulateAgentWithLargeListSessions(t, baseURL, agentToken, "fat-agent", payloadSize)
+	waitForAgent(t, h, "fat-agent")
+
+	agent, ok := h.Get("fat-agent")
+	if !ok {
+		t.Fatal("agent not found after registration")
+	}
+
+	// Open a terminal relay so we can prove terminals survive the large RPC.
+	sessionID := uuid.New()
+	relayCh, cleanup, err := h.OpenTerminalRelay(context.Background(), "fat-agent", sessionID)
+	if err != nil {
+		t.Fatalf("OpenTerminalRelay: %v", err)
+	}
+	defer cleanup()
+
+	req, _ := http.NewRequest("GET", baseURL+"/api/v1/agents/fat-agent/sessions", nil)
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %.200s", resp.StatusCode, body)
+	}
+	if len(body) < payloadSize {
+		t.Fatalf("expected passthrough body of at least %d bytes, got %d", payloadSize, len(body))
+	}
+	var result struct {
+		Sessions []struct {
+			ID            string `json:"id"`
+			PromptContext string `json:"prompt_context"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("unmarshal passthrough body: %v", err)
+	}
+	if len(result.Sessions) != 1 || result.Sessions[0].ID != "sess-1" || len(result.Sessions[0].PromptContext) != payloadSize {
+		t.Fatalf("passthrough body altered: sessions=%d", len(result.Sessions))
+	}
+
+	// The agent must still be online; poll briefly so a delayed offline
+	// transition (close handshake) cannot slip past the check.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if agent.Status() != hub.StatusOnline {
+			t.Fatalf("agent went offline after multi-MiB listSessions reply (status=%s)", agent.Status())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The relay channel must still be registered and open: push a frame
+	// through the agent connection and expect it on the channel.
+	select {
+	case _, open := <-relayCh:
+		if !open {
+			t.Fatal("terminal relay channel was closed by the large listSessions reply")
+		}
+		t.Fatal("unexpected frame on relay channel before any was sent")
+	default:
+	}
+	frame := hub.EncodeTerminalFrame(sessionID, []byte("0hello"))
+	if err := agentConn.Write(context.Background(), websocket.MessageBinary, frame); err != nil {
+		t.Fatalf("write relay frame after large reply — agent connection closed: %v", err)
+	}
+	select {
+	case payload, open := <-relayCh:
+		if !open {
+			t.Fatal("terminal relay channel closed after large listSessions reply")
+		}
+		if string(payload) != "0hello" {
+			t.Errorf("relay payload = %q, want %q", payload, "0hello")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for relay frame after large listSessions reply")
 	}
 }

--- a/services/agent-hub/internal/rest/middleware.go
+++ b/services/agent-hub/internal/rest/middleware.go
@@ -45,7 +45,6 @@ const rateLimiterMaxEntries = 300
 // without inserting the new IP into the map or touching any existing entry.
 var allProtectedLimiter = rate.NewLimiter(0, 0)
 
-
 // tokenAuth returns middleware that validates Bearer token authentication.
 func tokenAuth(token string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -117,7 +116,7 @@ func rateLimiterInternal(cfg config.RateLimitConfig, nowFn func() time.Time) (le
 	// once the burst has had time to fully replenish, the entry offers no
 	// stronger protection against a fresh connection than a brand-new entry
 	// would, so there is no reason to keep it pinned past that point.
-	deniedProtectionWindow := time.Duration(float64(cfg.Burst)/cfg.RequestsPerSecond * float64(time.Second))
+	deniedProtectionWindow := time.Duration(float64(cfg.Burst) / cfg.RequestsPerSecond * float64(time.Second))
 
 	var mu sync.Mutex
 	limiters := make(map[string]*lruEntry)
@@ -240,6 +239,12 @@ func bodyReadDeadlineMiddleware(timeout time.Duration) func(http.Handler) http.H
 
 // MaxRestBodySize is the maximum number of bytes accepted in a REST request body (1 MiB).
 const MaxRestBodySize = 1 << 20 // 1 MiB
+
+// MaxSessionRequestBodySize caps the body of per-session REST requests
+// (create session, send input), whose payloads are small (a session ID, a
+// profile name, a line of input). It is a REST-local limit, independent of
+// the agent WebSocket read backstop (hub.AgentMaxMessageSize).
+const MaxSessionRequestBodySize = 512 << 10 // 512 KiB
 
 // maxBodyMiddleware limits the size of request bodies to MaxRestBodySize bytes.
 // Requests that exceed the limit will receive HTTP 413 Request Entity Too Large.

--- a/services/agents/internal/config/config.go
+++ b/services/agents/internal/config/config.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	sharedrelay "github.com/dokipen/claude-cadence/services/shared/relay"
 )
 
 // AuthConfig holds authentication settings.
@@ -107,14 +109,14 @@ type Config struct {
 
 // CleanupConfig holds stale session cleanup settings.
 type CleanupConfig struct {
-	StaleSessionTTL        time.Duration `yaml:"-"`
-	ReapInterval           time.Duration `yaml:"-"`
-	CreatingSessionTTL     time.Duration `yaml:"-"`
-	ErrorSessionTTL        time.Duration `yaml:"-"`
-	RawTTL                 string        `yaml:"stale_session_ttl"`
-	RawReapInterval        string        `yaml:"session_reap_interval"`
-	RawCreatingSessionTTL  string        `yaml:"creating_session_ttl"`
-	RawErrorSessionTTL     string        `yaml:"error_session_ttl"`
+	StaleSessionTTL       time.Duration `yaml:"-"`
+	ReapInterval          time.Duration `yaml:"-"`
+	CreatingSessionTTL    time.Duration `yaml:"-"`
+	ErrorSessionTTL       time.Duration `yaml:"-"`
+	RawTTL                string        `yaml:"stale_session_ttl"`
+	RawReapInterval       string        `yaml:"session_reap_interval"`
+	RawCreatingSessionTTL string        `yaml:"creating_session_ttl"`
+	RawErrorSessionTTL    string        `yaml:"error_session_ttl"`
 }
 
 // TtydConfig holds ttyd websocket terminal settings.
@@ -324,10 +326,14 @@ func validate(cfg *Config) error {
 		}
 	}
 
-	// Validate PTY config.
-	const maxBufferSize = 1<<20 - 1 // ttyd frame prefix + buffer must fit in hub's MaxMessageSize
+	// Validate PTY config. A full-buffer snapshot replay is relayed to the hub
+	// as ttyd prefix (1) + buffer + relay header (17) =
+	// sharedrelay.MaxSnapshotFrameSize, which the hub's agent-connection read
+	// limit (sharedrelay.AgentMaxMessageSize) is sized to exceed. Capping the
+	// buffer here keeps that frame bound valid regardless of config.
+	const maxBufferSize = sharedrelay.MaxPTYBufferSize
 	if cfg.PTY.BufferSize > maxBufferSize {
-		return fmt.Errorf("pty.buffer_size (%d) must be <= %d to fit within hub proxy message limit", cfg.PTY.BufferSize, maxBufferSize)
+		return fmt.Errorf("pty.buffer_size (%d) must be <= %d so a full snapshot relay frame stays within the hub message limit", cfg.PTY.BufferSize, maxBufferSize)
 	}
 	if cfg.PTY.MaxSessions < 0 {
 		return fmt.Errorf("pty.max_sessions must be >= 0 (0 means unlimited)")

--- a/services/agents/internal/config/config_test.go
+++ b/services/agents/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	sharedrelay "github.com/dokipen/claude-cadence/services/shared/relay"
 )
 
 func validProfiles() map[string]Profile {
@@ -109,8 +111,6 @@ func TestValidate_InvalidAuthMode(t *testing.T) {
 		t.Fatal("expected error for invalid auth mode")
 	}
 }
-
-
 
 func TestResolveToken_ReturnsTokenWhenNoEnvVar(t *testing.T) {
 	a := &AuthConfig{Token: "hardcoded"}
@@ -366,6 +366,35 @@ func TestValidate_AdvertiseAddressEmptyAllowed(t *testing.T) {
 	}
 }
 
+func TestPTYConfig_Validate_BufferSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		bufferSize int
+		wantErr    bool
+	}{
+		{name: "at shared max", bufferSize: sharedrelay.MaxPTYBufferSize, wantErr: false},
+		{name: "one over shared max", bufferSize: sharedrelay.MaxPTYBufferSize + 1, wantErr: true},
+		{name: "zero uses default", bufferSize: 0, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Auth:     AuthConfig{Mode: "none"},
+				Profiles: validProfiles(),
+				Cleanup:  validCleanup(),
+				PTY:      PTYConfig{WebSocketScheme: "ws", BufferSize: tt.bufferSize},
+			}
+			err := validate(cfg)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error for buffer_size %d", tt.bufferSize)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error for buffer_size %d: %v", tt.bufferSize, err)
+			}
+		})
+	}
+}
+
 func TestPTYConfig_Validate_NegativeMaxSessions(t *testing.T) {
 	cfg := &Config{
 		Auth:     AuthConfig{Mode: "none"},
@@ -385,7 +414,7 @@ func TestPTYConfig_Validate_NegativeMaxSessions(t *testing.T) {
 
 func TestCleanupConfig_Validate_NegativeCreatingSessionTTL(t *testing.T) {
 	cfg := &Config{
-		Auth:    AuthConfig{Mode: "none"},
+		Auth:     AuthConfig{Mode: "none"},
 		Profiles: validProfiles(),
 		Cleanup: CleanupConfig{
 			StaleSessionTTL:    time.Hour,

--- a/services/agents/internal/hub/client.go
+++ b/services/agents/internal/hub/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coder/websocket"
@@ -23,6 +24,14 @@ import (
 // 256 entries absorbs larger PTY output bursts (e.g. cat of a large file) without
 // dropping frames or blocking the hub read loop.
 const terminalRelayChannelBufSize = 256
+
+// defaultMaxMessageBytes is the RPC message limit assumed when the hub's
+// register acknowledgement does not carry max_message_bytes. Hubs predating
+// issue #685 enforced a 512 KiB RPCMaxMessageSize on text frames and closed
+// the agent connection when it was exceeded, so this is the largest response
+// an un-negotiated hub is known to accept. Newer hubs advertise their real
+// (much larger) backstop in the register result, which takes precedence.
+const defaultMaxMessageBytes = 512 * 1024
 
 // SessionDispatcher handles session CRUD and terminal operations dispatched from the hub.
 type SessionDispatcher interface {
@@ -53,6 +62,13 @@ type Client struct {
 	// frames from the hub (browser input forwarded to the PTY session).
 	relayCh   map[string]chan []byte
 	relayChMu sync.Mutex
+
+	// maxMessageBytes is the largest JSON-RPC text frame the connected hub
+	// accepts, negotiated from the register acknowledgement (see
+	// registerResult). It is written by register() on every (re)connect and
+	// read by the dispatch goroutines, hence atomic. Zero means "not yet
+	// negotiated" and MaxMessageBytes() reports defaultMaxMessageBytes.
+	maxMessageBytes atomic.Int64
 }
 
 // NewClient creates a new hub client.
@@ -71,7 +87,7 @@ func NewClient(cfg config.HubConfig, profiles map[string]config.Profile, ttyd co
 		dispatcher: dispatcher,
 		ptyMgr:     mgr,
 		done:       make(chan struct{}),
-		relayCh: make(map[string]chan []byte),
+		relayCh:    make(map[string]chan []byte),
 	}
 }
 
@@ -211,7 +227,32 @@ func (c *Client) register(ctx context.Context, conn *websocket.Conn) error {
 		return fmt.Errorf("register rejected: %s", resp.Error.Message)
 	}
 
+	// Negotiate the RPC message limit. An older hub returns {accepted} only
+	// (or an empty object); fall back to defaultMaxMessageBytes in that case.
+	var result registerResult
+	if len(resp.Result) > 0 {
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			return fmt.Errorf("parse register result: %w", err)
+		}
+	}
+	limit := result.MaxMessageBytes
+	negotiated := limit > 0
+	if !negotiated {
+		limit = defaultMaxMessageBytes
+	}
+	c.maxMessageBytes.Store(limit)
+	slog.Info("hub message limit", "max_message_bytes", limit, "negotiated", negotiated)
+
 	return nil
+}
+
+// MaxMessageBytes returns the largest JSON-RPC response frame the hub accepts.
+// Before the first successful register it reports defaultMaxMessageBytes.
+func (c *Client) MaxMessageBytes() int64 {
+	if v := c.maxMessageBytes.Load(); v > 0 {
+		return v
+	}
+	return defaultMaxMessageBytes
 }
 
 func (c *Client) readLoop(ctx context.Context, conn *websocket.Conn) error {
@@ -300,7 +341,7 @@ func (c *Client) dispatchSessionAsync(ctx context.Context, conn *websocket.Conn,
 	}
 
 	resp := c.dispatchSession(req.ID, req.Params, fn)
-	if err := c.writeResponse(ctx, conn, resp); err != nil {
+	if err := c.writeResponseFor(ctx, conn, req.Method, resp); err != nil {
 		slog.Warn("failed to write dispatch response", "method", req.Method, "error", err)
 		return
 	}
@@ -323,15 +364,107 @@ func (c *Client) dispatchSessionAsync(ctx context.Context, conn *websocket.Conn,
 	}
 }
 
+// shrinkable is implemented by result types that can drop optional bulk
+// (today: per-session prompt_context) when a response would exceed the hub's
+// message limit. Shrink reports whether anything was actually removed, so the
+// caller can skip a pointless re-marshal.
+type shrinkable interface {
+	Shrink() bool
+}
+
+// shrinkableFor returns an empty result value of the type produced by method
+// that can be shrunk when oversized, or nil when the method's result carries
+// no droppable payload. The dispatcher hands results over as json.RawMessage,
+// so the degrade path re-decodes into the typed result to shrink it.
+func shrinkableFor(method string) shrinkable {
+	switch method {
+	case "listSessions":
+		return &sessionsJSON{}
+	case "getSession", "createSession":
+		return &sessionJSON{}
+	default:
+		return nil
+	}
+}
+
 // writeResponse serializes and writes a response, protected by the write mutex.
+// Responses whose result has no droppable payload (ping, ack-style methods)
+// use this directly; session dispatch goes through writeResponseFor so the
+// degrade path knows the result type.
 func (c *Client) writeResponse(ctx context.Context, conn *websocket.Conn, resp *response) error {
-	respData, _ := json.Marshal(resp)
+	return c.writeResponseFor(ctx, conn, "", resp)
+}
+
+// writeResponseFor serializes resp, bounds it to the hub's negotiated message
+// limit (degrading via shrinkableFor(method) or a JSON-RPC error, never
+// sending a frame the hub is known to reject), and writes it under writeMu.
+// All marshal/size work happens before the mutex is taken: writeMu is
+// non-reentrant and shared with the relay goroutines' binary-frame writes.
+func (c *Client) writeResponseFor(ctx context.Context, conn *websocket.Conn, method string, resp *response) error {
+	respData := prepareResponseFrame(method, resp, c.MaxMessageBytes(), shrinkableFor(method))
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 	if err := conn.Write(ctx, websocket.MessageText, respData); err != nil {
 		return fmt.Errorf("write response: %w", err)
 	}
 	return nil
+}
+
+// prepareResponseFrame returns the text frame to send for resp, guaranteed to
+// be at most limit bytes:
+//
+//  1. resp is marshaled as-is. A marshal failure becomes a JSON-RPC internal
+//     error for the same id (previously it was silently swallowed).
+//  2. If the frame exceeds limit and shrink is non-nil, the result is decoded
+//     into shrink, Shrink() drops its optional payload, and the response is
+//     re-marshaled.
+//  3. If the frame is still over limit (or nothing could be shrunk), a
+//     JSON-RPC internal error (-32000) for the same id replaces it.
+//
+// The error frame itself is tiny, so the returned bytes never exceed a limit
+// large enough to carry any JSON-RPC error envelope.
+func prepareResponseFrame(method string, resp *response, limit int64, shrink shrinkable) []byte {
+	respData, err := json.Marshal(resp)
+	if err != nil {
+		slog.Error("marshal response failed", "method", method, "id", resp.ID, "error", err)
+		return marshalErrorResponse(resp.ID, "internal error: failed to encode response")
+	}
+	if int64(len(respData)) <= limit {
+		return respData
+	}
+	originalSize := len(respData)
+
+	if shrink != nil && resp.Error == nil && len(resp.Result) > 0 {
+		if err := json.Unmarshal(resp.Result, shrink); err != nil {
+			slog.Warn("degrade: cannot decode result for shrinking", "method", method, "id", resp.ID, "error", err)
+		} else if shrink.Shrink() {
+			shrunk, err := json.Marshal(shrink)
+			if err == nil {
+				shrunkResp := &response{JSONRPC: resp.JSONRPC, ID: resp.ID, Result: shrunk}
+				if respData, err = json.Marshal(shrunkResp); err == nil && int64(len(respData)) <= limit {
+					slog.Warn("response exceeded hub message limit; sent without prompt_context",
+						"method", method, "id", resp.ID, "size", originalSize, "shrunk_size", len(respData), "limit", limit)
+					return respData
+				}
+			}
+		}
+	}
+
+	slog.Warn("response exceeds hub message limit; replaced with error",
+		"method", method, "id", resp.ID, "size", originalSize, "limit", limit)
+	return marshalErrorResponse(resp.ID,
+		fmt.Sprintf("response size %d exceeds hub message limit %d", originalSize, limit))
+}
+
+// marshalErrorResponse builds a JSON-RPC internal error (-32000) frame for id.
+// The envelope is built from fixed, well-formed fields so encoding cannot fail.
+func marshalErrorResponse(id, message string) []byte {
+	b, _ := json.Marshal(&response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: rpcErrInternal, Message: message},
+	})
+	return b
 }
 
 // RegisterRelaySession creates a buffered input channel for terminal relay
@@ -479,9 +612,9 @@ type rpcError struct {
 }
 
 type registerParams struct {
-	Name     string                  `json:"name"`
-	Profiles map[string]profileInfo  `json:"profiles"`
-	Ttyd     ttydInfo                `json:"ttyd"`
+	Name     string                 `json:"name"`
+	Profiles map[string]profileInfo `json:"profiles"`
+	Ttyd     ttydInfo               `json:"ttyd"`
 }
 
 type profileInfo struct {
@@ -497,6 +630,14 @@ type ttydInfo struct {
 	AdvertiseAddress string `json:"advertise_address"`
 	BasePort         int    `json:"base_port"`
 	MaxPorts         int    `json:"max_ports"`
+}
+
+// registerResult is the hub's acknowledgement of a register request.
+// MaxMessageBytes is the largest JSON-RPC text frame the hub will accept on
+// this connection; it is absent (zero) on hubs that predate issue #685.
+type registerResult struct {
+	Accepted        bool  `json:"accepted"`
+	MaxMessageBytes int64 `json:"max_message_bytes,omitempty"`
 }
 
 type pongResult struct {

--- a/services/agents/internal/hub/client_test.go
+++ b/services/agents/internal/hub/client_test.go
@@ -433,6 +433,16 @@ func TestClientRegisterNegotiatesMaxMessageBytes(t *testing.T) {
 			result: map[string]interface{}{},
 			want:   defaultMaxMessageBytes,
 		},
+		{
+			name:   "explicit zero falls back to default",
+			result: map[string]interface{}{"accepted": true, "max_message_bytes": 0},
+			want:   defaultMaxMessageBytes,
+		},
+		{
+			name:   "negative value falls back to default",
+			result: map[string]interface{}{"accepted": true, "max_message_bytes": -1},
+			want:   defaultMaxMessageBytes,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -504,8 +514,9 @@ func TestPrepareResponseFrame(t *testing.T) {
 		method        string
 		result        json.RawMessage
 		wantErr       bool
-		wantSessions  int  // sessions expected in a successful frame
-		wantPromptCtx bool // whether prompt_context must be present
+		wantErrMsg    string // substring expected in the error message (default: size-limit message)
+		wantSessions  int    // sessions expected in a successful frame
+		wantPromptCtx bool   // whether prompt_context must be present
 	}{
 		{
 			name:          "small listSessions passes through",
@@ -538,6 +549,16 @@ func TestPrepareResponseFrame(t *testing.T) {
 			result:  json.RawMessage(`{"blob":"` + strings.Repeat("z", 4096) + `"}`),
 			wantErr: true,
 		},
+		{
+			// A malformed RawMessage makes the initial json.Marshal(resp) fail;
+			// the frame must still be a well-formed JSON-RPC error for the
+			// same id rather than an empty/garbage payload.
+			name:       "malformed result becomes encode error",
+			method:     "listSessions",
+			result:     json.RawMessage("{not json"),
+			wantErr:    true,
+			wantErrMsg: "failed to encode response",
+		},
 	}
 
 	for _, tt := range tests {
@@ -569,8 +590,12 @@ func TestPrepareResponseFrame(t *testing.T) {
 				if got.Error.Code != rpcErrInternal {
 					t.Errorf("error code = %d, want %d", got.Error.Code, rpcErrInternal)
 				}
-				if !strings.Contains(got.Error.Message, "exceeds hub message limit") {
-					t.Errorf("error message = %q, want size-limit message", got.Error.Message)
+				wantMsg := tt.wantErrMsg
+				if wantMsg == "" {
+					wantMsg = "exceeds hub message limit"
+				}
+				if !strings.Contains(got.Error.Message, wantMsg) {
+					t.Errorf("error message = %q, want it to contain %q", got.Error.Message, wantMsg)
 				}
 				return
 			}

--- a/services/agents/internal/hub/client_test.go
+++ b/services/agents/internal/hub/client_test.go
@@ -366,3 +366,335 @@ func TestRegisterRelaySession_StaleCleanupDoesNotClobberLiveRegistration(t *test
 		t.Fatal("relayCh entry still present after cleanup2()")
 	}
 }
+
+// startRegisterAckServer runs a fake hub that answers the register request
+// with the given result object, then holds the connection open until the test
+// ends. It returns the ws:// URL to dial.
+func startRegisterAckServer(t *testing.T, result map[string]interface{}) string {
+	t.Helper()
+	connHold := make(chan struct{})
+	t.Cleanup(func() { close(connHold) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+
+		_, data, err := conn.Read(r.Context())
+		if err != nil {
+			return
+		}
+		var req struct {
+			ID string `json:"id"`
+		}
+		if jsonErr := json.Unmarshal(data, &req); jsonErr != nil {
+			return
+		}
+		ack, _ := json.Marshal(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  result,
+		})
+		if writeErr := conn.Write(r.Context(), websocket.MessageText, ack); writeErr != nil {
+			return
+		}
+		select {
+		case <-connHold:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+// TestClientRegisterNegotiatesMaxMessageBytes verifies that the register
+// acknowledgement's max_message_bytes is adopted as the client's message
+// limit, and that an ack without the field (older hub) yields the default.
+func TestClientRegisterNegotiatesMaxMessageBytes(t *testing.T) {
+	tests := []struct {
+		name   string
+		result map[string]interface{}
+		want   int64
+	}{
+		{
+			name:   "hub advertises limit",
+			result: map[string]interface{}{"accepted": true, "max_message_bytes": 16 << 20},
+			want:   16 << 20,
+		},
+		{
+			name:   "older hub omits field",
+			result: map[string]interface{}{"accepted": true},
+			want:   defaultMaxMessageBytes,
+		},
+		{
+			name:   "empty result object",
+			result: map[string]interface{}{},
+			want:   defaultMaxMessageBytes,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hubURL := startRegisterAckServer(t, tt.result)
+			cfg := config.HubConfig{
+				URL:               hubURL,
+				Name:              "test-agent",
+				Token:             "test-token",
+				ReconnectInterval: 50 * time.Millisecond,
+			}
+			client := NewClient(cfg, map[string]config.Profile{}, config.TtydConfig{}, &stubDispatcher{})
+
+			// Before any connection the default applies.
+			if got := client.MaxMessageBytes(); got != defaultMaxMessageBytes {
+				t.Fatalf("pre-connect MaxMessageBytes = %d, want default %d", got, defaultMaxMessageBytes)
+			}
+
+			client.Start()
+			t.Cleanup(client.Stop)
+
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				if client.maxMessageBytes.Load() != 0 {
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if got := client.MaxMessageBytes(); got != tt.want {
+				t.Fatalf("MaxMessageBytes = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// bigSessionsResult builds a listSessions-style result with n sessions, each
+// carrying a prompt_context of ctxLen bytes.
+func bigSessionsResult(t *testing.T, n, ctxLen int) json.RawMessage {
+	t.Helper()
+	infos := make([]sessionInfo, n)
+	for i := range infos {
+		infos[i] = sessionInfo{
+			ID:              uuid.New().String(),
+			Name:            "sess",
+			AgentProfile:    "profile",
+			State:           "running",
+			CreatedAt:       "2026-08-23T00:00:00Z",
+			WaitingForInput: true,
+			PromptContext:   strings.Repeat("x", ctxLen),
+			PromptType:      "question",
+		}
+	}
+	b, err := json.Marshal(sessionsJSON{Sessions: infos})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// TestPrepareResponseFrame covers the sender-side size guard: responses under
+// the limit pass through untouched, oversized shrinkable results are sent
+// without prompt_context, and anything still too large (or not shrinkable)
+// becomes a JSON-RPC error for the same id. No returned frame may exceed the
+// limit.
+func TestPrepareResponseFrame(t *testing.T) {
+	const limit = 2 * 1024
+
+	tests := []struct {
+		name          string
+		method        string
+		result        json.RawMessage
+		wantErr       bool
+		wantSessions  int  // sessions expected in a successful frame
+		wantPromptCtx bool // whether prompt_context must be present
+	}{
+		{
+			name:          "small listSessions passes through",
+			method:        "listSessions",
+			result:        bigSessionsResult(t, 1, 64),
+			wantSessions:  1,
+			wantPromptCtx: true,
+		},
+		{
+			name:         "oversized listSessions drops prompt_context",
+			method:       "listSessions",
+			result:       bigSessionsResult(t, 3, 4096),
+			wantSessions: 3,
+		},
+		{
+			name:    "oversized listSessions still too big after shrink becomes error",
+			method:  "listSessions",
+			result:  bigSessionsResult(t, 40, 1024), // ~40 × 200 B metadata > 2 KiB even shrunk
+			wantErr: true,
+		},
+		{
+			name:    "oversized non-shrinkable result becomes error",
+			method:  "getDiagnostics",
+			result:  json.RawMessage(`{"events":"` + strings.Repeat("y", 4096) + `"}`),
+			wantErr: true,
+		},
+		{
+			name:    "oversized result with no method context becomes error",
+			method:  "",
+			result:  json.RawMessage(`{"blob":"` + strings.Repeat("z", 4096) + `"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &response{JSONRPC: "2.0", ID: "req-42", Result: tt.result}
+			frame := prepareResponseFrame(tt.method, resp, limit, shrinkableFor(tt.method))
+
+			if int64(len(frame)) > limit {
+				t.Fatalf("frame size %d exceeds limit %d", len(frame), limit)
+			}
+
+			var got struct {
+				JSONRPC string          `json:"jsonrpc"`
+				ID      string          `json:"id"`
+				Result  json.RawMessage `json:"result"`
+				Error   *rpcError       `json:"error"`
+			}
+			if err := json.Unmarshal(frame, &got); err != nil {
+				t.Fatalf("frame is not valid JSON-RPC: %v", err)
+			}
+			if got.ID != "req-42" || got.JSONRPC != "2.0" {
+				t.Fatalf("envelope = id %q jsonrpc %q, want req-42 / 2.0", got.ID, got.JSONRPC)
+			}
+
+			if tt.wantErr {
+				if got.Error == nil {
+					t.Fatal("expected JSON-RPC error, got result")
+				}
+				if got.Error.Code != rpcErrInternal {
+					t.Errorf("error code = %d, want %d", got.Error.Code, rpcErrInternal)
+				}
+				if !strings.Contains(got.Error.Message, "exceeds hub message limit") {
+					t.Errorf("error message = %q, want size-limit message", got.Error.Message)
+				}
+				return
+			}
+
+			if got.Error != nil {
+				t.Fatalf("unexpected error: %+v", got.Error)
+			}
+			var sessions struct {
+				Sessions []map[string]json.RawMessage `json:"sessions"`
+			}
+			if err := json.Unmarshal(got.Result, &sessions); err != nil {
+				t.Fatalf("result is not a sessions list: %v", err)
+			}
+			if len(sessions.Sessions) != tt.wantSessions {
+				t.Fatalf("got %d sessions, want %d", len(sessions.Sessions), tt.wantSessions)
+			}
+			for i, s := range sessions.Sessions {
+				_, hasCtx := s["prompt_context"]
+				_, hasType := s["prompt_type"]
+				if hasCtx != tt.wantPromptCtx || hasType != tt.wantPromptCtx {
+					t.Errorf("session %d: prompt_context=%v prompt_type=%v, want both %v", i, hasCtx, hasType, tt.wantPromptCtx)
+				}
+				if _, ok := s["id"]; !ok {
+					t.Errorf("session %d lost its metadata", i)
+				}
+			}
+		})
+	}
+}
+
+// TestPrepareResponseFrame_SingleSession verifies the getSession/createSession
+// result type degrades the same way as listSessions.
+func TestPrepareResponseFrame_SingleSession(t *testing.T) {
+	const limit = 1024
+	result, err := json.Marshal(sessionJSON{Session: sessionInfo{
+		ID:            uuid.New().String(),
+		Name:          "sess",
+		AgentProfile:  "profile",
+		State:         "running",
+		CreatedAt:     "2026-08-23T00:00:00Z",
+		PromptContext: strings.Repeat("x", 4096),
+		PromptType:    "question",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, method := range []string{"getSession", "createSession"} {
+		t.Run(method, func(t *testing.T) {
+			resp := &response{JSONRPC: "2.0", ID: "req-7", Result: result}
+			frame := prepareResponseFrame(method, resp, limit, shrinkableFor(method))
+			if int64(len(frame)) > limit {
+				t.Fatalf("frame size %d exceeds limit %d", len(frame), limit)
+			}
+			var got struct {
+				ID     string `json:"id"`
+				Result struct {
+					Session map[string]json.RawMessage `json:"session"`
+				} `json:"result"`
+				Error *rpcError `json:"error"`
+			}
+			if err := json.Unmarshal(frame, &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.Error != nil {
+				t.Fatalf("unexpected error: %+v", got.Error)
+			}
+			if got.ID != "req-7" {
+				t.Errorf("id = %q, want req-7", got.ID)
+			}
+			if _, ok := got.Result.Session["prompt_context"]; ok {
+				t.Error("prompt_context still present after degrade")
+			}
+			if _, ok := got.Result.Session["id"]; !ok {
+				t.Error("session metadata lost")
+			}
+		})
+	}
+}
+
+// TestPrepareResponseFrame_ErrorResponsePassesThrough verifies that a
+// dispatcher error response is never treated as shrinkable and is forwarded
+// unchanged when it fits.
+func TestPrepareResponseFrame_ErrorResponsePassesThrough(t *testing.T) {
+	resp := &response{JSONRPC: "2.0", ID: "req-9", Error: &rpcError{Code: rpcErrNotFound, Message: "no such session"}}
+	frame := prepareResponseFrame("getSession", resp, 2048, shrinkableFor("getSession"))
+	var got response
+	if err := json.Unmarshal(frame, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Error == nil || got.Error.Code != rpcErrNotFound || got.Error.Message != "no such session" {
+		t.Fatalf("error response altered: %s", frame)
+	}
+}
+
+// TestShrink covers the Shrink implementations directly, including the
+// "nothing to remove" signal that lets the caller skip a re-marshal.
+func TestShrink(t *testing.T) {
+	t.Run("sessionsJSON", func(t *testing.T) {
+		r := &sessionsJSON{Sessions: []sessionInfo{
+			{ID: "a", PromptContext: "ctx", PromptType: "question"},
+			{ID: "b"},
+		}}
+		if !r.Shrink() {
+			t.Fatal("Shrink() = false, want true when prompt payload present")
+		}
+		for _, s := range r.Sessions {
+			if s.PromptContext != "" || s.PromptType != "" {
+				t.Errorf("session %s still carries prompt payload", s.ID)
+			}
+		}
+		if r.Shrink() {
+			t.Error("second Shrink() = true, want false (nothing left to remove)")
+		}
+	})
+	t.Run("sessionJSON", func(t *testing.T) {
+		r := &sessionJSON{Session: sessionInfo{ID: "a", PromptType: "question"}}
+		if !r.Shrink() {
+			t.Fatal("Shrink() = false, want true")
+		}
+		if r.Session.PromptType != "" {
+			t.Error("prompt_type not cleared")
+		}
+		if (&sessionJSON{}).Shrink() {
+			t.Error("Shrink() on empty session = true, want false")
+		}
+	})
+}

--- a/services/agents/internal/hub/dispatch.go
+++ b/services/agents/internal/hub/dispatch.go
@@ -16,12 +16,12 @@ import (
 
 // JSON-RPC error codes matching the hub protocol.
 const (
-	rpcErrNotFound            = -32001
-	rpcErrAlreadyExists       = -32002
-	rpcErrInvalidArgument     = -32003
-	rpcErrFailedPrecondition  = -32004
-	rpcErrResourceExhausted   = -32005
-	rpcErrInternal            = -32000
+	rpcErrNotFound           = -32001
+	rpcErrAlreadyExists      = -32002
+	rpcErrInvalidArgument    = -32003
+	rpcErrFailedPrecondition = -32004
+	rpcErrResourceExhausted  = -32005
+	rpcErrInternal           = -32000
 )
 
 // Dispatcher implements SessionDispatcher by calling the session manager directly.
@@ -59,10 +59,11 @@ func (d *Dispatcher) CreateSession(params json.RawMessage) (json.RawMessage, *rp
 		return nil, mapSessionError(err)
 	}
 
-	return marshalResult(sessionJSON{Session: toSessionInfo(sess)})
+	return marshalResult(sessionJSON{Session: toSessionInfo(sess, true)})
 }
 
-// GetSession handles the getSession JSON-RPC method.
+// GetSession handles the getSession JSON-RPC method. This is the per-session
+// path that carries prompt_context/prompt_type; listSessions omits them.
 func (d *Dispatcher) GetSession(params json.RawMessage) (json.RawMessage, *rpcError) {
 	var p getSessionParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -74,10 +75,19 @@ func (d *Dispatcher) GetSession(params json.RawMessage) (json.RawMessage, *rpcEr
 		return nil, mapSessionError(err)
 	}
 
-	return marshalResult(sessionJSON{Session: toSessionInfo(sess)})
+	return marshalResult(sessionJSON{Session: toSessionInfo(sess, true)})
 }
 
 // ListSessions handles the listSessions JSON-RPC method.
+//
+// The response is metadata-only and bounded by construction: each session
+// contributes a fixed set of small fields (IDs, names, paths, URLs, state,
+// timestamps, the waiting_for_input flag and idle_since), each with a small
+// worst-case length, so the frame size is O(N) in the number of sessions with
+// a small constant. prompt_context/prompt_type are derived from the PTY ring
+// buffer and are the only unbounded per-session payload; they are omitted here
+// and served per-session via getSession. Callers use waiting_for_input and
+// idle_since from this list to decide which sessions to fetch (issue #685).
 func (d *Dispatcher) ListSessions(params json.RawMessage) (json.RawMessage, *rpcError) {
 	var p listSessionsParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -113,7 +123,7 @@ func (d *Dispatcher) ListSessions(params json.RawMessage) (json.RawMessage, *rpc
 
 	infos := make([]sessionInfo, len(sessions))
 	for i, s := range sessions {
-		infos[i] = toSessionInfo(s)
+		infos[i] = toSessionInfo(s, false)
 	}
 
 	return marshalResult(sessionsJSON{Sessions: infos})
@@ -232,7 +242,47 @@ type sessionsJSON struct {
 	Sessions []sessionInfo `json:"sessions"`
 }
 
-func toSessionInfo(s *session.Session) sessionInfo {
+// shrink drops the optional prompt payload from info, reporting whether
+// anything was removed. prompt_context is derived from the PTY ring buffer
+// and is the only unbounded field on a session; everything else is small
+// metadata.
+func (info *sessionInfo) shrink() bool {
+	if info.PromptContext == "" && info.PromptType == "" {
+		return false
+	}
+	info.PromptContext = ""
+	info.PromptType = ""
+	return true
+}
+
+// Shrink implements shrinkable: when a getSession/createSession response
+// exceeds the hub message limit, the prompt payload is dropped rather than
+// failing the call.
+func (r *sessionJSON) Shrink() bool {
+	return r.Session.shrink()
+}
+
+// Shrink implements shrinkable: when a listSessions response exceeds the hub
+// message limit, every session's prompt payload is dropped so the metadata
+// still reaches the hub. In practice listSessions no longer carries
+// prompt_context/prompt_type at all (see ListSessions), so this is
+// defense-in-depth and normally reports false.
+func (r *sessionsJSON) Shrink() bool {
+	removed := false
+	for i := range r.Sessions {
+		if r.Sessions[i].shrink() {
+			removed = true
+		}
+	}
+	return removed
+}
+
+// toSessionInfo converts a session to its wire representation. When
+// includePrompt is false, prompt_context/prompt_type are left empty so the
+// omitempty tags drop them from the JSON entirely; list-shaped responses
+// (listSessions, getDiagnostics) use this to stay bounded, while per-session
+// responses (getSession, createSession) include the prompt payload.
+func toSessionInfo(s *session.Session, includePrompt bool) sessionInfo {
 	if s == nil {
 		return sessionInfo{}
 	}
@@ -249,8 +299,10 @@ func toSessionInfo(s *session.Session) sessionInfo {
 		AgentPID:        s.AgentPID,
 		WebsocketURL:    s.WebsocketURL,
 		WaitingForInput: s.WaitingForInput,
-		PromptContext:   s.PromptContext,
-		PromptType:      s.PromptType,
+	}
+	if includePrompt {
+		info.PromptContext = s.PromptContext
+		info.PromptType = s.PromptType
 	}
 	if s.IdleSince != nil {
 		t := s.IdleSince.Format(time.RFC3339)
@@ -342,7 +394,9 @@ func (d *Dispatcher) GetDiagnostics(ctx context.Context, params json.RawMessage)
 	byState.Creating = []sessionInfo{}
 
 	for _, s := range sessions {
-		info := toSessionInfo(s)
+		// Metadata-only for the same reason as ListSessions: this is a
+		// list-shaped response and must stay bounded.
+		info := toSessionInfo(s, false)
 		switch s.State {
 		case session.StateRunning:
 			byState.Running = append(byState.Running, info)
@@ -449,7 +503,7 @@ func marshalResult(v any) (json.RawMessage, *rpcError) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		slog.Error("marshal result failed", "error", err)
-	return nil, &rpcError{Code: rpcErrInternal, Message: "internal error"}
+		return nil, &rpcError{Code: rpcErrInternal, Message: "internal error"}
 	}
 	return b, nil
 }

--- a/services/agents/internal/hub/dispatch_test.go
+++ b/services/agents/internal/hub/dispatch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dokipen/claude-cadence/services/agents/internal/config"
 	"github.com/dokipen/claude-cadence/services/agents/internal/pty"
 	"github.com/dokipen/claude-cadence/services/agents/internal/session"
+	sharedrelay "github.com/dokipen/claude-cadence/services/shared/relay"
 )
 
 // newFakeManager creates a session.Manager backed by an in-memory store
@@ -62,6 +63,167 @@ func TestDispatcher_ListSessions_Empty(t *testing.T) {
 	}
 	if len(out.Sessions) != 0 {
 		t.Errorf("expected 0 sessions, got %d", len(out.Sessions))
+	}
+}
+
+// TestDispatcher_ListSessions_OmitsPromptContext verifies the Layer 3 contract
+// from issue #685: listSessions is metadata-only (no prompt_context/prompt_type
+// keys at all, but still waiting_for_input/idle_since so callers know which
+// sessions to fetch), while getSession for the same id carries the prompt
+// payload. Assertions are on raw JSON keys because omitempty makes an absent
+// key and an empty string indistinguishable once decoded into sessionInfo.
+func TestDispatcher_ListSessions_OmitsPromptContext(t *testing.T) {
+	const id = "550e8400-e29b-41d4-a716-446655440010"
+	idle := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	store := session.NewStore()
+	store.Add(&session.Session{
+		ID:              id,
+		Name:            "prompt-session",
+		AgentProfile:    "default",
+		State:           session.StateRunning,
+		WaitingForInput: true,
+		IdleSince:       &idle,
+		PromptContext:   "Do you want to proceed? (y/n)",
+		PromptType:      "yes_no",
+	})
+	mgr := session.NewManager(store, nil, nil, nil, map[string]config.Profile{}, 0)
+	d := NewDispatcher(mgr, "127.0.0.1", "ws", "", nil)
+
+	decodeKeys := func(t *testing.T, raw json.RawMessage) map[string]any {
+		t.Helper()
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("unmarshal into map: %v", err)
+		}
+		return m
+	}
+
+	// listSessions: metadata only.
+	listRaw, rpcErr := d.ListSessions(json.RawMessage(`{}`))
+	if rpcErr != nil {
+		t.Fatalf("ListSessions: unexpected error: %v", rpcErr)
+	}
+	for _, key := range []string{"prompt_context", "prompt_type"} {
+		if strings.Contains(string(listRaw), `"`+key+`"`) {
+			t.Errorf("ListSessions JSON must not contain key %q, got: %s", key, listRaw)
+		}
+	}
+	listSessions, ok := decodeKeys(t, listRaw)["sessions"].([]any)
+	if !ok || len(listSessions) != 1 {
+		t.Fatalf("expected 1 session in list, got: %s", listRaw)
+	}
+	listEntry := listSessions[0].(map[string]any)
+	if v, ok := listEntry["waiting_for_input"].(bool); !ok || !v {
+		t.Errorf("ListSessions entry must carry waiting_for_input=true, got: %v", listEntry["waiting_for_input"])
+	}
+	if _, ok := listEntry["idle_since"].(string); !ok {
+		t.Errorf("ListSessions entry must carry idle_since, got: %v", listEntry["idle_since"])
+	}
+	if _, present := listEntry["prompt_context"]; present {
+		t.Error("ListSessions entry must not have prompt_context key")
+	}
+	if _, present := listEntry["prompt_type"]; present {
+		t.Error("ListSessions entry must not have prompt_type key")
+	}
+
+	// getSession: full per-session payload.
+	getRaw, rpcErr := d.GetSession(json.RawMessage(fmt.Sprintf(`{"session_id":%q}`, id)))
+	if rpcErr != nil {
+		t.Fatalf("GetSession: unexpected error: %v", rpcErr)
+	}
+	getEntry, ok := decodeKeys(t, getRaw)["session"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected session object, got: %s", getRaw)
+	}
+	if got, _ := getEntry["prompt_context"].(string); got != "Do you want to proceed? (y/n)" {
+		t.Errorf("GetSession prompt_context = %q, want stored value", got)
+	}
+	if got, _ := getEntry["prompt_type"].(string); got != "yes_no" {
+		t.Errorf("GetSession prompt_type = %q, want stored value", got)
+	}
+	if v, ok := getEntry["waiting_for_input"].(bool); !ok || !v {
+		t.Errorf("GetSession must carry waiting_for_input=true, got: %v", getEntry["waiting_for_input"])
+	}
+}
+
+// Worst-case sizing for the bounded listSessions payload test. These are
+// deliberately generous upper bounds on each metadata field so the test fails
+// loudly if a future field addition (or an unbounded field leaking back into
+// the list) blows the budget. Real values are far smaller: IDs are 36-char
+// UUIDs, names/profiles are short slugs, paths and URLs are a few hundred
+// bytes at most.
+const (
+	// listSessionsWorstCaseSessions is the number of sessions in the
+	// synthetic list. pty.max_sessions is configurable (0 = unlimited), so
+	// this is a realistic operational ceiling rather than a hard cap.
+	listSessionsWorstCaseSessions = 200
+	// listSessionsWorstCaseShortField bounds short identifiers: id, name,
+	// agent_profile, state, base_ref, created_at, idle_since.
+	listSessionsWorstCaseShortField = 256
+	// listSessionsWorstCaseLongField bounds the longer free-form strings:
+	// worktree_path, repo_url, websocket_url, error_message.
+	listSessionsWorstCaseLongField = 1024
+	// listSessionsWorstCasePerSession is the budget for one serialized
+	// session: 7 short fields + 4 long fields + JSON framing (keys, quotes,
+	// commas, the agent_pid int and waiting_for_input bool). Keep this in
+	// sync with sessionInfo; adding a field to the list response must be
+	// accounted for here.
+	listSessionsWorstCasePerSession = 7*listSessionsWorstCaseShortField + 4*listSessionsWorstCaseLongField + 512
+)
+
+// TestListSessions_WorstCasePayloadBounded asserts that a listSessions
+// response at a realistic upper bound (many sessions, every metadata field at
+// a generous worst-case length) stays comfortably under the hub's agent
+// message limit. This is the bound that makes listSessions "bounded by
+// construction" per issue #685: the only unbounded field (prompt_context) is
+// never present in the list, so the size is N * (small constant).
+func TestListSessions_WorstCasePayloadBounded(t *testing.T) {
+	short := strings.Repeat("s", listSessionsWorstCaseShortField)
+	long := strings.Repeat("L", listSessionsWorstCaseLongField)
+
+	infos := make([]sessionInfo, listSessionsWorstCaseSessions)
+	for i := range infos {
+		idle := short
+		infos[i] = sessionInfo{
+			ID:              short,
+			Name:            short,
+			AgentProfile:    short,
+			State:           short,
+			WorktreePath:    long,
+			RepoURL:         long,
+			BaseRef:         short,
+			CreatedAt:       short,
+			ErrorMessage:    long,
+			AgentPID:        2147483647,
+			WebsocketURL:    long,
+			WaitingForInput: true,
+			IdleSince:       &idle,
+			// PromptContext/PromptType intentionally absent: ListSessions
+			// never populates them (see toSessionInfo includePrompt=false).
+		}
+	}
+
+	b, err := json.Marshal(sessionsJSON{Sessions: infos})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	size := len(b)
+	budget := listSessionsWorstCaseSessions * listSessionsWorstCasePerSession
+	limit := sharedrelay.AgentMaxMessageSize / 4
+	t.Logf("worst-case listSessions payload: sessions=%d size=%d bytes (per-session budget=%d, total budget=%d, hub limit/4=%d)",
+		listSessionsWorstCaseSessions, size, listSessionsWorstCasePerSession, budget, limit)
+
+	if size > budget {
+		t.Errorf("serialized size %d exceeds per-session budget total %d; a field was added to sessionInfo without updating listSessionsWorstCasePerSession", size, budget)
+	}
+	if size >= limit {
+		t.Errorf("serialized size %d must be < AgentMaxMessageSize/4 (%d)", size, limit)
+	}
+
+	// The per-session budget must itself be meaningful: a sessionsJSON made
+	// of these sessions must not be able to carry the unbounded field.
+	if strings.Contains(string(b), `"prompt_context"`) {
+		t.Error("worst-case list payload must not contain prompt_context")
 	}
 }
 

--- a/services/agents/internal/hub/relay.go
+++ b/services/agents/internal/hub/relay.go
@@ -116,7 +116,7 @@ func (c *Client) runTerminalRelay(
 		// pastes (e.g. base64 payloads) would exceed the default 32 KB limit and
 		// silently kill the ServeTerminal read loop. The loopback listener is
 		// process-internal and not reachable from external hosts.
-		conn.SetReadLimit(int64(ptyMgr.BufferSize() + 1))
+		conn.SetReadLimit(int64(ptyMgr.BufferSize() + sharedrelay.TtydFramePrefixLen))
 		defer conn.CloseNow()
 		_ = ptyMgr.ServeTerminal(r.Context(), ptySessID, conn)
 	})
@@ -139,8 +139,10 @@ func (c *Client) runTerminalRelay(
 
 	// ServeTerminal replays the full ring-buffer snapshot on connect, which can
 	// exceed coder/websocket's default 32 KB read limit. Set the read limit to
-	// the configured buffer size + 1 byte (for the ttyd frame prefix).
-	localConn.SetReadLimit(int64(ptyMgr.BufferSize() + 1))
+	// the configured buffer size + the ttyd frame prefix. This is the local
+	// (ttyd-framed) size; on the hub link the frame additionally carries the
+	// relay header, for a worst case of sharedrelay.MaxSnapshotFrameSize.
+	localConn.SetReadLimit(int64(ptyMgr.BufferSize() + sharedrelay.TtydFramePrefixLen))
 
 	slog.Debug("relay: terminal relay started", "session_id", ptySessID)
 

--- a/services/agents/internal/pty/manager.go
+++ b/services/agents/internal/pty/manager.go
@@ -13,19 +13,26 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/creack/pty"
+
+	sharedrelay "github.com/dokipen/claude-cadence/services/shared/relay"
 )
 
-// defaultBufferSize is 1 byte less than 1 MB so that a ttyd replay frame
-// (1-byte type prefix + buffer contents) fits within the hub proxy's
-// MaxMessageSize (1 << 20) read limit.
-const defaultBufferSize = 1<<20 - 1
+// defaultBufferSize is the ring buffer capacity (and the maximum pty.buffer_size
+// config accepts). A full-buffer snapshot replay over the hub relay is framed
+// as: ttyd type prefix (sharedrelay.TtydFramePrefixLen = 1) + buffer contents
+// + relay header (sharedrelay.TerminalFrameHeaderLen = 17), i.e.
+// sharedrelay.MaxSnapshotFrameSize bytes. The hub's agent-connection read
+// limit (sharedrelay.AgentMaxMessageSize) must exceed that frame size, or a
+// single replay closes the whole agent connection (issue #685).
+const defaultBufferSize = sharedrelay.MaxPTYBufferSize
 
 const maxResizeDimension uint16 = 500
 
 // PTYConfig holds configuration for PTYManager.
 type PTYConfig struct {
-	// BufferSize is the ring buffer capacity in bytes. Defaults to (1<<20)-1
-	// to leave room for the ttyd frame prefix within the hub proxy's 1 MB limit.
+	// BufferSize is the ring buffer capacity in bytes. Defaults to
+	// defaultBufferSize (sharedrelay.MaxPTYBufferSize); see that constant for
+	// how it relates to the hub relay frame size.
 	BufferSize int
 	// MaxSessions is the maximum number of concurrent sessions. Zero means unlimited.
 	MaxSessions int
@@ -33,18 +40,18 @@ type PTYConfig struct {
 
 // session holds per-session PTY state.
 type session struct {
-	id         string
-	cmd        *exec.Cmd
-	master     *os.File    // PTY master
-	rb         *RingBuffer
-	writers    []io.Writer  // active WS writers (stub for future broadcast)
-	writerGen  uint64       // incremented each time a new writer is registered; used to avoid stale cleanup
-	done       chan struct{} // closed when PTY read goroutine exits AND cmd.Wait() has returned
-	waitOnce   sync.Once   // ensures cmd.Wait() is called exactly once
-	waitErr    error       // result of cmd.Wait(), set by waitOnce
-	closeOnce  sync.Once   // ensures master.Close() is called exactly once (idempotent across Destroy and Reattach goroutine)
-	mu         sync.Mutex
-	slavePath  string      // /dev/pts/N path of the slave side of the PTY
+	id        string
+	cmd       *exec.Cmd
+	master    *os.File // PTY master
+	rb        *RingBuffer
+	writers   []io.Writer   // active WS writers (stub for future broadcast)
+	writerGen uint64        // incremented each time a new writer is registered; used to avoid stale cleanup
+	done      chan struct{} // closed when PTY read goroutine exits AND cmd.Wait() has returned
+	waitOnce  sync.Once     // ensures cmd.Wait() is called exactly once
+	waitErr   error         // result of cmd.Wait(), set by waitOnce
+	closeOnce sync.Once     // ensures master.Close() is called exactly once (idempotent across Destroy and Reattach goroutine)
+	mu        sync.Mutex
+	slavePath string // /dev/pts/N path of the slave side of the PTY
 }
 
 // closeMaster closes the PTY master fd idempotently. The second and subsequent

--- a/services/agents/internal/pty/manager_test.go
+++ b/services/agents/internal/pty/manager_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	sharedrelay "github.com/dokipen/claude-cadence/services/shared/relay"
 )
 
 // pollBuffer polls ReadBuffer until the output contains want or the deadline passes.
@@ -199,17 +201,20 @@ func TestSession_closeMaster_idempotent(t *testing.T) {
 }
 
 // TestDefaultBufferSize_FitsWithFramePrefix verifies that a full ring buffer
-// replay frame (1-byte ttyd type prefix + buffer contents) does not exceed the
-// hub proxy's MaxMessageSize (1 << 20). This guards against the off-by-one
-// that caused #344: terminal connections dropped when the buffer was full.
+// snapshot replay, framed for the hub relay (ttyd type prefix + buffer +
+// relay header), stays below the hub's agent-connection read limit. This
+// guards against the off-by-one that caused #344 and the 17-byte relay header
+// overflow behind #685: terminal connections dropped when the buffer was full.
 func TestDefaultBufferSize_FitsWithFramePrefix(t *testing.T) {
-	const maxMessageSize = 1 << 20 // must match hub.MaxMessageSize
-	const framePrefixLen = 1       // ttyd type byte ('0')
-	frameSize := framePrefixLen + defaultBufferSize
-	if frameSize > maxMessageSize {
-		t.Errorf("full replay frame (%d bytes) exceeds MaxMessageSize (%d); "+
-			"defaultBufferSize must be at most %d",
-			frameSize, maxMessageSize, maxMessageSize-framePrefixLen)
+	if defaultBufferSize != sharedrelay.MaxPTYBufferSize {
+		t.Fatalf("defaultBufferSize = %d, want sharedrelay.MaxPTYBufferSize (%d)", defaultBufferSize, sharedrelay.MaxPTYBufferSize)
+	}
+	frameSize := sharedrelay.TtydFramePrefixLen + defaultBufferSize + sharedrelay.TerminalFrameHeaderLen
+	if frameSize != sharedrelay.MaxSnapshotFrameSize {
+		t.Errorf("full replay frame = %d bytes, want sharedrelay.MaxSnapshotFrameSize (%d)", frameSize, sharedrelay.MaxSnapshotFrameSize)
+	}
+	if frameSize >= sharedrelay.AgentMaxMessageSize {
+		t.Errorf("full replay frame (%d bytes) is not below the hub read limit (%d)", frameSize, sharedrelay.AgentMaxMessageSize)
 	}
 }
 

--- a/services/issues-ui/src/api/agentHubClient.test.ts
+++ b/services/issues-ui/src/api/agentHubClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { create } from "@bufbuild/protobuf";
-import { hubFetch, fetchAgents, createSession, HubError } from "./agentHubClient";
+import { hubFetch, fetchAgents, createSession, fetchSession, HubError } from "./agentHubClient";
 import { AgentSchema, SessionSchema } from "../gen/hub/v1/hub_pb";
 
 function mockFetch(response: {
@@ -443,5 +443,61 @@ describe("createSession", () => {
     );
     expect(err).toBeInstanceOf(HubError);
     expect(err).toMatchObject({ status: 502 });
+  });
+});
+
+describe("fetchSession", () => {
+  // Per-session endpoint: unlike the bulk list, this carries the prompt payload (#685).
+  const sessionJson = {
+    id: "sess-1",
+    name: "lead-42",
+    agent_profile: "default",
+    state: "running",
+    created_at: "2026-03-22T00:00:00Z",
+    waiting_for_input: true,
+    idle_since: "2026-03-22T00:05:00Z",
+    prompt_context: "? Continue\n❯ Yes\n  No",
+    prompt_type: "select",
+  };
+
+  it("GETs the per-session URL and returns a typed Session with prompt fields", async () => {
+    const fn = mockFetch({ json: () => Promise.resolve({ session: sessionJson }) });
+    const result = await fetchSession("my agent/v2", "id:with/slash");
+    expect(fn).toHaveBeenCalledWith(
+      "/api/v1/agents/my%20agent%2Fv2/sessions/id%3Awith%2Fslash",
+      expect.objectContaining({ headers: {} }),
+    );
+    expect(result).toEqual(
+      create(SessionSchema, {
+        id: "sess-1",
+        name: "lead-42",
+        agentProfile: "default",
+        state: "running",
+        createdAt: "2026-03-22T00:00:00Z",
+        waitingForInput: true,
+        idleSince: "2026-03-22T00:05:00Z",
+        promptContext: "? Continue\n❯ Yes\n  No",
+        promptType: "select",
+      }),
+    );
+  });
+
+  it("throws HubError when the session envelope is missing", async () => {
+    mockFetch({ json: () => Promise.resolve(sessionJson) });
+    const err = await fetchSession("a", "s").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(HubError);
+    expect(err).toMatchObject({ status: 502 });
+  });
+
+  it("throws HubError on non-OK response", async () => {
+    mockFetch({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve({ error: "session not found" }),
+    });
+    const err = await fetchSession("a", "missing").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(HubError);
+    expect(err).toMatchObject({ status: 404, message: "session not found" });
   });
 });

--- a/services/issues-ui/src/api/agentHubClient.ts
+++ b/services/issues-ui/src/api/agentHubClient.ts
@@ -117,6 +117,25 @@ export async function fetchAllSessions(): Promise<AgentSessions[]> {
   return hubFetch("/sessions", undefined, validateAllSessionsResponse);
 }
 
+function validateSessionEnvelope(data: unknown): Session {
+  if (!isRecord(data) || !isRecord(data.session)) {
+    throw new HubError(502, 'Invalid session response: expected object with "session" key');
+  }
+  return parseSession(data.session);
+}
+
+/**
+ * Fetch a single session. Unlike the bulk list (which is metadata-only, see
+ * issue #685), this response includes promptContext/promptType.
+ */
+export async function fetchSession(agentName: string, sessionId: string): Promise<Session> {
+  return hubFetch(
+    `/agents/${encodeURIComponent(agentName)}/sessions/${encodeURIComponent(sessionId)}`,
+    undefined,
+    validateSessionEnvelope,
+  );
+}
+
 export async function deleteSession(agentName: string, sessionId: string): Promise<void> {
   try {
     await hubFetch(
@@ -157,11 +176,6 @@ export async function createSession(
   return hubFetch(
     `/agents/${encodeURIComponent(agentName)}/sessions`,
     { method: "POST", body: JSON.stringify(body) },
-    (data) => {
-      if (!isRecord(data) || !isRecord(data.session)) {
-        throw new HubError(502, 'Invalid session response: expected object with "session" key');
-      }
-      return parseSession(data.session);
-    },
+    validateSessionEnvelope,
   );
 }

--- a/services/issues-ui/src/components/NotificationDropdown.test.tsx
+++ b/services/issues-ui/src/components/NotificationDropdown.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
 import React from "react";
 
 // Mock CSS modules
@@ -20,6 +20,7 @@ vi.mock("react-router", () => ({
 // Mock agentHubClient
 vi.mock("../api/agentHubClient", () => ({
   sendSessionInput: vi.fn().mockResolvedValue(undefined),
+  fetchSession: vi.fn(),
   fetchAgents: vi.fn(),
   fetchAllSessions: vi.fn(),
   createSession: vi.fn(),
@@ -39,15 +40,26 @@ vi.mock("../hooks/useTicketByNumber", () => ({
 import { NotificationDropdown } from "./NotificationDropdown";
 import type { AgentSession } from "../hooks/useAllSessions";
 import type { Session } from "../types";
-import { sendSessionInput } from "../api/agentHubClient";
+import { sendSessionInput, fetchSession } from "../api/agentHubClient";
 import { useTicketByNumber } from "../hooks/useTicketByNumber";
 
 afterEach(() => {
   cleanup();
 });
 
+// The bulk list no longer carries promptContext/promptType (#685); the
+// component fetches them per waiting session via fetchSession. Fixtures built
+// with makeAgentSession are registered here so the mock can serve them back.
+const sessionRegistry = new Map<string, Session>();
+
 beforeEach(() => {
   vi.resetAllMocks();
+  sessionRegistry.clear();
+  vi.mocked(fetchSession).mockImplementation(async (agentName, sessionId) => {
+    const session = sessionRegistry.get(`${agentName}:${sessionId}`);
+    if (!session) throw new Error(`no fixture for ${agentName}:${sessionId}`);
+    return session;
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -70,10 +82,19 @@ function makeAgentSession(
   agentName = "lead",
   sessionOverrides: Partial<Session> = {},
 ): AgentSession {
-  return {
-    agentName,
-    session: makeSession(sessionOverrides),
-  };
+  const session = makeSession(sessionOverrides);
+  sessionRegistry.set(`${agentName}:${session.id}`, session);
+  return { agentName, session };
+}
+
+/** Open the dropdown and wait for the per-session prompt fetch to settle. */
+async function openAndLoad(
+  utils: ReturnType<typeof render>,
+): Promise<void> {
+  fireEvent.click(utils.getByTestId("notification-trigger"));
+  await waitFor(() => {
+    expect(utils.queryByTestId("prompt-loading")).toBeNull();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -293,10 +314,11 @@ describe("NotificationDropdown — yesno prompt", () => {
         promptContext: "Do you want to continue? (y/N)",
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
     fireEvent.click(getByTestId("btn-yes"));
 
     // sendSessionInput is async; wait for it to be called
@@ -315,10 +337,11 @@ describe("NotificationDropdown — yesno prompt", () => {
         promptContext: "Do you want to continue? (y/N)",
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
     fireEvent.click(getByTestId("btn-no"));
 
     await vi.waitFor(() => {
@@ -340,10 +363,11 @@ describe("NotificationDropdown — parseSelectPrompt no ❯ marker", () => {
         promptContext: contextNoMarker,
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     // Click Option B (index 1) — currentIndex defaults to 0, delta = 1, one down arrow
     fireEvent.click(getByTestId("btn-option-1"));
@@ -357,7 +381,7 @@ describe("NotificationDropdown — parseSelectPrompt no ❯ marker", () => {
 describe("NotificationDropdown — select prompt", () => {
   const selectContext = "? Pick one\n  Option A\n❯ Option B\n  Option C";
 
-  it("renders a button for each parsed option", () => {
+  it("renders a button for each parsed option", async () => {
     const sessions = [
       makeAgentSession("lead", {
         id: "sess-select",
@@ -365,10 +389,11 @@ describe("NotificationDropdown — select prompt", () => {
         promptContext: selectContext,
       }),
     ];
-    const { getByTestId, getByText } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId, getByText } = utils;
+    await openAndLoad(utils);
 
     // Options: "Option A", "Option B", "Option C"
     expect(getByText("Option A")).toBeTruthy();
@@ -387,10 +412,11 @@ describe("NotificationDropdown — select prompt", () => {
         promptContext: selectContext,
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     // Click Option C (index 2) — delta = 2 - 1 = 1, down arrow once + \r
     fireEvent.click(getByTestId("btn-option-2"));
@@ -402,17 +428,18 @@ describe("NotificationDropdown — select prompt", () => {
 });
 
 describe("NotificationDropdown — text input prompt", () => {
-  it("renders a text input and Send button", () => {
+  it("renders a text input and Send button", async () => {
     const sessions = [
       makeAgentSession("lead", {
         id: "sess-text",
         promptType: "text",
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     expect(getByTestId("text-input")).toBeTruthy();
     expect(getByTestId("btn-send")).toBeTruthy();
@@ -427,10 +454,11 @@ describe("NotificationDropdown — text input prompt", () => {
         promptType: "text",
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     const input = getByTestId("text-input") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "typed text" } });
@@ -451,10 +479,11 @@ describe("NotificationDropdown — controls do not navigate", () => {
         promptContext: "Continue? (y/N)",
       }),
     ];
-    const { getByTestId, queryByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId, queryByTestId } = utils;
+    await openAndLoad(utils);
 
     // Controls are siblings of <Link>, not nested inside it.
     // Clicking a control button does not trigger the link's onClick (onClose).
@@ -463,7 +492,7 @@ describe("NotificationDropdown — controls do not navigate", () => {
     expect(queryByTestId("notification-dropdown")).toBeTruthy();
   });
 
-  it("clicking a select option keeps the dropdown open", () => {
+  it("clicking a select option keeps the dropdown open", async () => {
     const sessions = [
       makeAgentSession("lead", {
         id: "sess-select-open",
@@ -471,32 +500,34 @@ describe("NotificationDropdown — controls do not navigate", () => {
         promptContext: "? Pick one\n  Option A\n❯ Option B",
       }),
     ];
-    const { getByTestId, queryByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId, queryByTestId } = utils;
+    await openAndLoad(utils);
     fireEvent.click(getByTestId("btn-option-0"));
     expect(queryByTestId("notification-dropdown")).toBeTruthy();
   });
 
-  it("clicking the Send button keeps the dropdown open", () => {
+  it("clicking the Send button keeps the dropdown open", async () => {
     const sessions = [
       makeAgentSession("lead", {
         id: "sess-text-open",
         promptType: "text",
       }),
     ];
-    const { getByTestId, queryByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId, queryByTestId } = utils;
+    await openAndLoad(utils);
     fireEvent.click(getByTestId("btn-send"));
     expect(queryByTestId("notification-dropdown")).toBeTruthy();
   });
 });
 
 describe("NotificationDropdown — ticket title", () => {
-  it("shows ticket title when useTicketByNumber returns a ticket", () => {
+  it("shows ticket title when useTicketByNumber returns a ticket", async () => {
     vi.mocked(useTicketByNumber).mockReturnValue({
       ticket: { id: "t1", number: 42, title: "Add sound effects" },
       loading: false,
@@ -506,10 +537,11 @@ describe("NotificationDropdown — ticket title", () => {
     const sessions = [
       makeAgentSession("lead", { id: "s1", name: "lead-42" }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId="proj-1" projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     expect(getByTestId("notification-item").textContent).toContain("Add sound effects");
   });
@@ -519,7 +551,7 @@ describe("NotificationDropdown — ticket title", () => {
     ["discuss", "discuss-42"],
     ["tester", "tester-42"],
     ["security-engineer", "security-engineer-42"],
-  ])("shows ticket title for %s sessions", (agentName, sessionName) => {
+  ])("shows ticket title for %s sessions", async (agentName, sessionName) => {
     vi.mocked(useTicketByNumber).mockReturnValue({
       ticket: { id: "t1", number: 42, title: "Add sound effects" },
       loading: false,
@@ -527,16 +559,17 @@ describe("NotificationDropdown — ticket title", () => {
     });
 
     const sessions = [makeAgentSession(agentName, { id: "s1", name: sessionName })];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId="proj-1" projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     expect(vi.mocked(useTicketByNumber)).toHaveBeenCalledWith("proj-1", 42);
     expect(getByTestId("notification-item").textContent).toContain("Add sound effects");
   });
 
-  it("shows session name as fallback when no ticket is found", () => {
+  it("shows session name as fallback when no ticket is found", async () => {
     vi.mocked(useTicketByNumber).mockReturnValue({
       ticket: null,
       loading: false,
@@ -546,10 +579,11 @@ describe("NotificationDropdown — ticket title", () => {
     const sessions = [
       makeAgentSession("lead", { id: "s1", name: "general-work" }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     expect(getByTestId("notification-item").textContent).toContain("general-work");
   });
@@ -566,10 +600,11 @@ describe("NotificationDropdown — error state on sendSessionInput rejection", (
         promptContext: "Continue? (y/N)",
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
     fireEvent.click(getByTestId("btn-yes"));
 
     await vi.waitFor(() => {
@@ -586,10 +621,11 @@ describe("NotificationDropdown — error state on sendSessionInput rejection", (
         promptType: "text",
       }),
     ];
-    const { getByTestId, queryByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId, queryByTestId } = utils;
+    await openAndLoad(utils);
 
     // Trigger the error
     fireEvent.click(getByTestId("btn-send"));
@@ -605,21 +641,23 @@ describe("NotificationDropdown — error state on sendSessionInput rejection", (
 
 describe("NotificationDropdown — Sent state", () => {
   it("Yes button becomes disabled after click", async () => {
+    const sessions = [
+      makeAgentSession("lead", {
+        id: "sess-sent",
+        promptType: "yesno",
+        promptContext: "Continue? (y/N)",
+      }),
+    ];
+    const utils = render(
+      <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
+    );
+    const { getByTestId } = utils;
+    // Let the prompt fetch settle on real timers before faking them.
+    await openAndLoad(utils);
+
     vi.useFakeTimers();
 
     try {
-      const sessions = [
-        makeAgentSession("lead", {
-          id: "sess-sent",
-          promptType: "yesno",
-          promptContext: "Continue? (y/N)",
-        }),
-      ];
-      const { getByTestId } = render(
-        <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
-      );
-      fireEvent.click(getByTestId("notification-trigger"));
-
       const yesBtn = getByTestId("btn-yes") as HTMLButtonElement;
       expect(yesBtn.disabled).toBe(false);
 
@@ -655,10 +693,11 @@ describe("NotificationDropdown — select prompt delta variants", () => {
         promptContext: selectContext,
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     // Click Option B (index 1) — delta = 0, just \r
     fireEvent.click(getByTestId("btn-option-1"));
@@ -678,10 +717,11 @@ describe("NotificationDropdown — select prompt delta variants", () => {
         promptContext: selectContext,
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     // Click Option A (index 0) — delta = 0 - 1 = -1, one up arrow + \r
     fireEvent.click(getByTestId("btn-option-0"));
@@ -703,10 +743,11 @@ describe("NotificationDropdown — select prompt delta variants", () => {
         promptContext: multiStepContext,
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     // Click Option C (index 2) — delta = 2, two down arrows + \r
     fireEvent.click(getByTestId("btn-option-2"));
@@ -728,10 +769,11 @@ describe("NotificationDropdown — text input Enter key submission", () => {
         promptType: "text",
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     const input = getByTestId("text-input") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "hello" } });
@@ -744,17 +786,18 @@ describe("NotificationDropdown — text input Enter key submission", () => {
 });
 
 describe("NotificationDropdown — unknown promptType fallback", () => {
-  it("renders no controls when promptType is unrecognized", () => {
+  it("renders no controls when promptType is unrecognized", async () => {
     const sessions = [
       makeAgentSession("lead", {
         id: "sess-unknown",
         promptType: "unknown-type" as never,
       }),
     ];
-    const { getByTestId, queryByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId, queryByTestId } = utils;
+    await openAndLoad(utils);
 
     expect(queryByTestId("btn-yes")).toBeNull();
     expect(queryByTestId("btn-no")).toBeNull();
@@ -765,7 +808,7 @@ describe("NotificationDropdown — unknown promptType fallback", () => {
 });
 
 describe("NotificationDropdown — yesno with empty promptContext", () => {
-  it("renders Yes/No buttons but no promptContext pre-block when promptContext is empty", () => {
+  it("renders Yes/No buttons but no promptContext pre-block when promptContext is empty", async () => {
     const sessions = [
       makeAgentSession("lead", {
         id: "sess-yesno-empty",
@@ -773,10 +816,11 @@ describe("NotificationDropdown — yesno with empty promptContext", () => {
         promptContext: "",
       }),
     ];
-    const { getByTestId } = render(
+    const utils = render(
       <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
     );
-    fireEvent.click(getByTestId("notification-trigger"));
+    const { getByTestId } = utils;
+    await openAndLoad(utils);
 
     expect(getByTestId("btn-yes")).toBeTruthy();
     expect(getByTestId("btn-no")).toBeTruthy();
@@ -789,21 +833,23 @@ describe("NotificationDropdown — yesno with empty promptContext", () => {
 
 describe("NotificationDropdown — timer leak on unmount (#496)", () => {
   it("does not leave a pending setSent timer after the component unmounts", async () => {
+    const sessions = [
+      makeAgentSession("lead", {
+        id: "sess-timer-leak",
+        promptType: "yesno",
+        promptContext: "Continue? (y/N)",
+      }),
+    ];
+    const utils = render(
+      <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
+    );
+    const { getByTestId, unmount } = utils;
+    // Let the prompt fetch settle on real timers before faking them.
+    await openAndLoad(utils);
+
     vi.useFakeTimers();
 
     try {
-      const sessions = [
-        makeAgentSession("lead", {
-          id: "sess-timer-leak",
-          promptType: "yesno",
-          promptContext: "Continue? (y/N)",
-        }),
-      ];
-      const { getByTestId, unmount } = render(
-        <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
-      );
-      fireEvent.click(getByTestId("notification-trigger"));
-
       const yesBtn = getByTestId("btn-yes") as HTMLButtonElement;
       fireEvent.click(yesBtn);
 
@@ -823,5 +869,161 @@ describe("NotificationDropdown — timer leak on unmount (#496)", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-session prompt fetch (#685): the bulk list is metadata-only
+// ---------------------------------------------------------------------------
+
+describe("NotificationDropdown — per-session prompt fetch (#685)", () => {
+  it("does not fetch any session while the dropdown is closed", () => {
+    const sessions = [makeAgentSession("lead", { id: "s1" })];
+    render(
+      <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
+    );
+    expect(fetchSession).not.toHaveBeenCalled();
+  });
+
+  it("fetches each waiting session once when the dropdown opens", async () => {
+    const sessions = [
+      makeAgentSession("lead", { id: "s1", promptType: "yesno", promptContext: "A?" }),
+      makeAgentSession("mac", { id: "s2", promptType: "text" }),
+    ];
+    const utils = render(
+      <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
+    );
+    await openAndLoad(utils);
+
+    expect(fetchSession).toHaveBeenCalledTimes(2);
+    expect(fetchSession).toHaveBeenCalledWith("lead", "s1");
+    expect(fetchSession).toHaveBeenCalledWith("mac", "s2");
+  });
+
+  it("shows a loading line first, then the fetched prompt text and controls", async () => {
+    let resolveFetch: (s: Session) => void = () => {};
+    const session = makeSession({ id: "s1", promptType: "yesno", promptContext: "Proceed? (y/N)" });
+    vi.mocked(fetchSession).mockImplementation(
+      () => new Promise<Session>((resolve) => { resolveFetch = resolve; }),
+    );
+    // The list item itself carries no prompt fields.
+    const sessions: AgentSession[] = [
+      { agentName: "lead", session: makeSession({ id: "s1", promptType: undefined, promptContext: undefined }) },
+    ];
+    const { getByTestId, queryByTestId, findByText, queryByText } = render(
+      <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
+    );
+    fireEvent.click(getByTestId("notification-trigger"));
+
+    // Loading state: dimmed placeholder, no prompt text, no controls yet.
+    expect(getByTestId("prompt-loading").textContent).toBe("Loading prompt…");
+    expect(queryByText("Proceed? (y/N)")).toBeNull();
+    expect(queryByTestId("btn-yes")).toBeNull();
+    expect(queryByTestId("text-input")).toBeNull();
+
+    await act(async () => {
+      resolveFetch(session);
+    });
+
+    expect(await findByText("Proceed? (y/N)")).toBeTruthy();
+    expect(queryByTestId("prompt-loading")).toBeNull();
+    expect(getByTestId("btn-yes")).toBeTruthy();
+    expect(getByTestId("btn-no")).toBeTruthy();
+  });
+
+  it("renders select options from the fetched promptContext", async () => {
+    const sessions = [
+      makeAgentSession("lead", {
+        id: "s-sel",
+        promptType: "select",
+        promptContext: "? Pick one\n  Alpha\n❯ Beta",
+      }),
+    ];
+    const { getByTestId, findByText } = render(
+      <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
+    );
+    fireEvent.click(getByTestId("notification-trigger"));
+
+    expect(await findByText("Alpha")).toBeTruthy();
+    expect(await findByText("Beta")).toBeTruthy();
+  });
+
+  it("degrades gracefully on fetch error: item renders without prompt text, text input fallback", async () => {
+    vi.mocked(fetchSession).mockRejectedValue(new Error("hub unavailable"));
+    const sessions = [makeAgentSession("lead", { id: "s-err", name: "lead-7" })];
+    const utils = render(
+      <NotificationDropdown waitingSessions={sessions} projectId={undefined} projectName={null} />,
+    );
+    const { getByTestId, queryByTestId } = utils;
+    await openAndLoad(utils);
+
+    const item = getByTestId("notification-item");
+    expect(item.textContent).toContain("lead-7");
+    expect(item.querySelector("pre")).toBeNull();
+    expect(queryByTestId("prompt-loading")).toBeNull();
+    expect(queryByTestId("btn-yes")).toBeNull();
+    // No send error is shown for a prompt fetch failure.
+    expect(queryByTestId("send-error")).toBeNull();
+    // The generic text input remains so the user can still answer.
+    expect(getByTestId("text-input")).toBeTruthy();
+    expect(getByTestId("btn-send")).toBeTruthy();
+  });
+
+  it("refetches when idleSince changes for the same session (new prompt)", async () => {
+    const first = makeAgentSession("lead", {
+      id: "s-idle",
+      idleSince: "2026-08-23T10:00:00Z",
+      promptType: "yesno",
+      promptContext: "First? (y/N)",
+    });
+    const utils = render(
+      <NotificationDropdown waitingSessions={[first]} projectId={undefined} projectName={null} />,
+    );
+    const { findByText, rerender, queryByText } = utils;
+    await openAndLoad(utils);
+    expect(await findByText("First? (y/N)")).toBeTruthy();
+    expect(fetchSession).toHaveBeenCalledTimes(1);
+
+    // Same session id, new idleSince (bulk poll saw a new prompt); registry now
+    // serves the new prompt payload.
+    const second = makeAgentSession("lead", {
+      id: "s-idle",
+      idleSince: "2026-08-23T10:05:00Z",
+      promptType: "select",
+      promptContext: "? Next\n❯ One\n  Two",
+    });
+    rerender(
+      <NotificationDropdown waitingSessions={[second]} projectId={undefined} projectName={null} />,
+    );
+
+    expect(await findByText("One")).toBeTruthy();
+    expect(queryByText("First? (y/N)")).toBeNull();
+    expect(fetchSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refetch on rerender when idleSince is unchanged", async () => {
+    const ws = makeAgentSession("lead", {
+      id: "s-same",
+      idleSince: "2026-08-23T10:00:00Z",
+      promptType: "yesno",
+      promptContext: "Same? (y/N)",
+    });
+    const utils = render(
+      <NotificationDropdown waitingSessions={[ws]} projectId={undefined} projectName={null} />,
+    );
+    const { rerender } = utils;
+    await openAndLoad(utils);
+    expect(fetchSession).toHaveBeenCalledTimes(1);
+
+    // A fresh object with identical data (as a bulk poll would produce).
+    rerender(
+      <NotificationDropdown
+        waitingSessions={[{ ...ws, session: { ...ws.session } }]}
+        projectId={undefined}
+        projectName={null}
+      />,
+    );
+    await waitFor(() => expect(utils.queryByTestId("prompt-loading")).toBeNull());
+    expect(fetchSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/issues-ui/src/components/NotificationDropdown.tsx
+++ b/services/issues-ui/src/components/NotificationDropdown.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router";
 import type { AgentSession } from "../hooks/useAllSessions";
 import { useTicketByNumber } from "../hooks/useTicketByNumber";
+import { useSessionPromptContext } from "../hooks/useSessionPromptContext";
 import { sendSessionInput } from "../api/agentHubClient";
 import layoutStyles from "../styles/layout.module.css";
 import { stripProjectPrefix } from "../utils/sessionName";
@@ -59,8 +60,17 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
 
   const linkTo = `/agents?session=${encodeURIComponent(ws.agentName)}:${encodeURIComponent(ws.session.id)}`;
 
-  const promptContext = ws.session.promptContext ?? "";
-  const promptType = ws.session.promptType ?? "";
+  // The bulk session list is metadata-only (#685): fetch the prompt payload
+  // per waiting session. idleSince changes whenever a new prompt appears, which
+  // triggers a refetch.
+  const prompt = useSessionPromptContext(
+    ws.agentName,
+    ws.session.id,
+    ws.session.waitingForInput,
+    ws.session.idleSince,
+  );
+  const promptContext = prompt.promptContext ?? "";
+  const promptType = prompt.promptType ?? "";
 
   useEffect(() => {
     return () => {
@@ -124,12 +134,17 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
           )}
         </div>
       </Link>
+      {prompt.loading && (
+        <div className={layoutStyles.notificationPromptLoading} data-testid="prompt-loading">
+          Loading prompt…
+        </div>
+      )}
       {promptContext && (
         <pre className={layoutStyles.notificationPromptText}>
           {promptContext}
         </pre>
       )}
-      {promptType === "yesno" && (
+      {!prompt.loading && promptType === "yesno" && (
         <div className={layoutStyles.notificationControlsRow}>
           <button
             className={`${layoutStyles.notificationControlBtn} ${layoutStyles.notificationControlBtnPrimary}`}
@@ -149,7 +164,7 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
           </button>
         </div>
       )}
-      {promptType === "select" && (
+      {!prompt.loading && promptType === "select" && (
         <div className={layoutStyles.notificationControlsRow}>
           {parseSelectPrompt(promptContext).options.map((option, idx) => (
             <button
@@ -164,7 +179,7 @@ function NotificationItem({ ws, projectId, projectName, onClose }: NotificationI
           ))}
         </div>
       )}
-      {(promptType === "text" || promptType === "shell" || promptType === "") && (
+      {!prompt.loading && (promptType === "text" || promptType === "shell" || promptType === "") && (
         <div className={layoutStyles.notificationInputRow}>
           <input
             className={layoutStyles.notificationTextInput}

--- a/services/issues-ui/src/hooks/useSessionPromptContext.test.ts
+++ b/services/issues-ui/src/hooks/useSessionPromptContext.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+
+import { vi } from "vitest";
+
+const { mockFetchSession } = vi.hoisted(() => ({
+  mockFetchSession: vi.fn(),
+}));
+
+vi.mock("../api/agentHubClient", () => ({
+  fetchSession: mockFetchSession,
+}));
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import { SessionSchema } from "../gen/hub/v1/hub_pb";
+import { useSessionPromptContext } from "./useSessionPromptContext";
+import type { Session } from "../types";
+
+function makeSession(overrides: Partial<{ promptContext: string; promptType: string }> = {}): Session {
+  return create(SessionSchema, {
+    id: "sess-1",
+    agentProfile: "default",
+    name: "lead-42",
+    state: "running",
+    waitingForInput: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    idleSince: "2024-01-01T00:01:00Z",
+    ...overrides,
+  }) as unknown as Session;
+}
+
+interface HookProps {
+  agentName: string;
+  sessionId: string;
+  enabled: boolean;
+  idleSince: string | undefined;
+}
+
+function renderPromptHook(initial: Partial<HookProps> = {}) {
+  const initialProps: HookProps = {
+    agentName: "mac",
+    sessionId: "sess-1",
+    enabled: true,
+    idleSince: "2024-01-01T00:01:00Z",
+    ...initial,
+  };
+  return renderHook(
+    ({ agentName, sessionId, enabled, idleSince }: HookProps) =>
+      useSessionPromptContext(agentName, sessionId, enabled, idleSince),
+    { initialProps },
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockFetchSession.mockResolvedValue(makeSession());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useSessionPromptContext", () => {
+  it("does not fetch when disabled and returns empty values", () => {
+    const { result } = renderPromptHook({ enabled: false });
+    expect(mockFetchSession).not.toHaveBeenCalled();
+    expect(result.current).toEqual({
+      promptContext: undefined,
+      promptType: undefined,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("fetches once when enabled and exposes promptContext/promptType", async () => {
+    mockFetchSession.mockResolvedValue(
+      makeSession({ promptContext: "? Continue (y/N)", promptType: "yesno" }),
+    );
+    const { result } = renderPromptHook();
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockFetchSession).toHaveBeenCalledTimes(1);
+    expect(mockFetchSession).toHaveBeenCalledWith("mac", "sess-1");
+    expect(result.current.promptContext).toBe("? Continue (y/N)");
+    expect(result.current.promptType).toBe("yesno");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not refetch on rerender with unchanged inputs", async () => {
+    const { result, rerender } = renderPromptHook();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    rerender({ agentName: "mac", sessionId: "sess-1", enabled: true, idleSince: "2024-01-01T00:01:00Z" });
+
+    expect(mockFetchSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when idleSince changes", async () => {
+    mockFetchSession
+      .mockResolvedValueOnce(makeSession({ promptContext: "first prompt", promptType: "yesno" }))
+      .mockResolvedValueOnce(makeSession({ promptContext: "second prompt", promptType: "select" }));
+
+    const { result, rerender } = renderPromptHook();
+    await waitFor(() => expect(result.current.promptContext).toBe("first prompt"));
+
+    rerender({ agentName: "mac", sessionId: "sess-1", enabled: true, idleSince: "2024-01-01T00:05:00Z" });
+
+    // A new prompt invalidates the old one: loading again with stale values cleared.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.promptContext).toBeUndefined();
+
+    await waitFor(() => expect(result.current.promptContext).toBe("second prompt"));
+    expect(result.current.promptType).toBe("select");
+    expect(mockFetchSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears values and does not fetch again when disabled after being enabled", async () => {
+    mockFetchSession.mockResolvedValue(makeSession({ promptContext: "ctx", promptType: "yesno" }));
+    const { result, rerender } = renderPromptHook();
+    await waitFor(() => expect(result.current.promptContext).toBe("ctx"));
+
+    rerender({ agentName: "mac", sessionId: "sess-1", enabled: false, idleSince: undefined });
+
+    expect(result.current).toEqual({
+      promptContext: undefined,
+      promptType: undefined,
+      loading: false,
+      error: null,
+    });
+    expect(mockFetchSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a stale result when inputs change before it resolves", async () => {
+    let resolveFirst: (s: Session) => void = () => {};
+    mockFetchSession
+      .mockImplementationOnce(
+        () => new Promise<Session>((resolve) => { resolveFirst = resolve; }),
+      )
+      .mockResolvedValueOnce(makeSession({ promptContext: "fresh", promptType: "text" }));
+
+    const { result, rerender } = renderPromptHook();
+    expect(result.current.loading).toBe(true);
+
+    rerender({ agentName: "mac", sessionId: "sess-1", enabled: true, idleSince: "2024-01-01T00:09:00Z" });
+    await waitFor(() => expect(result.current.promptContext).toBe("fresh"));
+
+    // The first (stale) request resolves late and must not overwrite the fresh result.
+    await act(async () => {
+      resolveFirst(makeSession({ promptContext: "stale", promptType: "yesno" }));
+    });
+    expect(result.current.promptContext).toBe("fresh");
+    expect(result.current.promptType).toBe("text");
+  });
+
+  it("does not update state when unmounted before the fetch resolves", async () => {
+    let resolveFetch: (s: Session) => void = () => {};
+    mockFetchSession.mockImplementation(
+      () => new Promise<Session>((resolve) => { resolveFetch = resolve; }),
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result, unmount } = renderPromptHook();
+    expect(result.current.loading).toBe(true);
+
+    unmount();
+
+    await act(async () => {
+      resolveFetch(makeSession({ promptContext: "late", promptType: "yesno" }));
+    });
+
+    expect(consoleError).not.toHaveBeenCalled();
+    // Snapshot is frozen at unmount: the late result was ignored.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.promptContext).toBeUndefined();
+  });
+
+  it("sets error and leaves promptContext undefined when the fetch rejects", async () => {
+    mockFetchSession.mockRejectedValue(new Error("boom"));
+    const { result } = renderPromptHook();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("boom");
+    expect(result.current.promptContext).toBeUndefined();
+    expect(result.current.promptType).toBeUndefined();
+  });
+
+  it("uses a fallback message for non-Error rejections", async () => {
+    mockFetchSession.mockRejectedValue("nope");
+    const { result } = renderPromptHook();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Failed to load prompt");
+  });
+});

--- a/services/issues-ui/src/hooks/useSessionPromptContext.ts
+++ b/services/issues-ui/src/hooks/useSessionPromptContext.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect } from "react";
+import { fetchSession } from "../api/agentHubClient";
+
+export interface UseSessionPromptContextResult {
+  promptContext: string | undefined;
+  promptType: string | undefined;
+  loading: boolean;
+  error: string | null;
+}
+
+const IDLE: UseSessionPromptContextResult = {
+  promptContext: undefined,
+  promptType: undefined,
+  loading: false,
+  error: null,
+};
+
+/**
+ * Fetch promptContext/promptType for a single session on demand.
+ *
+ * The bulk session list (GET /api/v1/sessions) is metadata-only (issue #685):
+ * it carries waitingForInput and idleSince but not the prompt payload. This
+ * hook fetches the full session only while `enabled` (i.e. the session is
+ * waiting for input) and refetches when `idleSince` changes — a new prompt on
+ * the same session produces a new idleSince, so the bulk poll drives refreshes.
+ * The hook does no polling of its own.
+ */
+export function useSessionPromptContext(
+  agentName: string,
+  sessionId: string,
+  enabled: boolean,
+  idleSince: string | undefined,
+): UseSessionPromptContextResult {
+  const [result, setResult] = useState<UseSessionPromptContextResult>(IDLE);
+
+  useEffect(() => {
+    if (!enabled) {
+      setResult(IDLE);
+      return;
+    }
+
+    let cancelled = false;
+    setResult({ ...IDLE, loading: true });
+
+    fetchSession(agentName, sessionId)
+      .then((session) => {
+        if (cancelled) return;
+        setResult({
+          promptContext: session.promptContext,
+          promptType: session.promptType,
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setResult({
+          ...IDLE,
+          error: err instanceof Error ? err.message : "Failed to load prompt",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agentName, sessionId, enabled, idleSince]);
+
+  return result;
+}

--- a/services/issues-ui/src/styles/layout.module.css
+++ b/services/issues-ui/src/styles/layout.module.css
@@ -264,6 +264,14 @@
   padding: 0.3rem 0.5rem;
 }
 
+.notificationPromptLoading {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  opacity: 0.7;
+  margin: 0 0.75rem;
+  padding: 0.3rem 0.5rem;
+}
+
 .notificationControlsRow {
   display: flex;
   gap: 0.4rem;

--- a/services/shared/relay/relay.go
+++ b/services/shared/relay/relay.go
@@ -10,4 +10,30 @@ const (
 	FrameTypeRelayEnd byte = 0x02
 	// TerminalFrameHeaderLen is 1 (type byte) + 16 (UUID bytes).
 	TerminalFrameHeaderLen = 17
+
+	// TtydFramePrefixLen is the 1-byte ttyd server→client frame type prefix
+	// ('0' for output) that precedes raw terminal bytes inside a terminal
+	// relay payload.
+	TtydFramePrefixLen = 1
+
+	// MaxPTYBufferSize is the largest PTY ring buffer agentd accepts
+	// (pty.buffer_size). It is also the default ring buffer capacity.
+	MaxPTYBufferSize = 1<<20 - 1
+
+	// MaxSnapshotFrameSize is the largest terminal relay frame agentd can emit:
+	// a full ring-buffer snapshot replay wrapped in the ttyd prefix and the
+	// relay header. The hub's agent-connection read limit MUST exceed this
+	// value, otherwise a single snapshot replay closes the whole agent
+	// connection (see issue #685).
+	MaxSnapshotFrameSize = MaxPTYBufferSize + TtydFramePrefixLen + TerminalFrameHeaderLen
+
+	// AgentMaxMessageSize is the hub's read limit for a single WebSocket
+	// message on the agent connection (both JSON-RPC text frames and binary
+	// relay frames). It is a bug backstop against runaway allocation, not a
+	// protocol constraint: every legitimate message is bounded by construction
+	// far below this value (MaxSnapshotFrameSize for relay, a metadata-only
+	// listSessions for RPC). Do not tune this downward to "catch" oversized
+	// payloads — exceeding it closes the agent connection, which is the worst
+	// possible response to a payload bug.
+	AgentMaxMessageSize = 16 << 20
 )

--- a/services/shared/relay/relay_test.go
+++ b/services/shared/relay/relay_test.go
@@ -1,0 +1,29 @@
+package relay
+
+import "testing"
+
+// TestMaxSnapshotFrameSize pins the worst-case relay frame to its components
+// so a change to any one of them (ring buffer, ttyd prefix, relay header)
+// cannot silently desynchronise the derived constant.
+func TestMaxSnapshotFrameSize(t *testing.T) {
+	want := MaxPTYBufferSize + TtydFramePrefixLen + TerminalFrameHeaderLen
+	if MaxSnapshotFrameSize != want {
+		t.Fatalf("MaxSnapshotFrameSize = %d, want MaxPTYBufferSize+TtydFramePrefixLen+TerminalFrameHeaderLen = %d", MaxSnapshotFrameSize, want)
+	}
+	if MaxSnapshotFrameSize != 1048593 {
+		t.Errorf("MaxSnapshotFrameSize = %d, want 1048593 (1<<20 - 1 + 1 + 17)", MaxSnapshotFrameSize)
+	}
+}
+
+// TestAgentMaxMessageSizeBackstopMargin asserts the hub's agent-connection
+// read limit exceeds the largest legitimate frame by a comfortable margin.
+// The backstop exists to catch bugs, never to police legitimate traffic; a
+// full ring-buffer snapshot replay landing within a few bytes of it is
+// exactly how issue #685 took agents offline.
+func TestAgentMaxMessageSizeBackstopMargin(t *testing.T) {
+	const minMargin = 4
+	if AgentMaxMessageSize < minMargin*MaxSnapshotFrameSize {
+		t.Fatalf("AgentMaxMessageSize (%d) must be at least %dx MaxSnapshotFrameSize (%d)",
+			AgentMaxMessageSize, minMargin, MaxSnapshotFrameSize)
+	}
+}


### PR DESCRIPTION
## Summary

The `mac` agentd flapped offline whenever a long-lived session was hovered in the sidebar. The hover opens the terminal relay, which replays the PTY ring buffer; a full buffer (1 MiB − 1) + ttyd prefix (1) + relay header (17) = **1,048,593 bytes — 17 over the hub's 1 MiB read limit** — so the websocket library closed the *entire* agent connection and every relayed terminal with it. Same class as #400 / #531 / #677: a size guard on the wire policing data that was never bounded by construction. This PR removes the mechanism rather than moving the threshold.

- **`services/shared/relay`**: `TtydFramePrefixLen`, `MaxPTYBufferSize`, `MaxSnapshotFrameSize`, and a 16 MiB `AgentMaxMessageSize` backstop so both modules compile against the same numbers; test asserts `MaxSnapshotFrameSize < AgentMaxMessageSize` with ≥4× margin.
- **`services/agent-hub`**: agent-link read limit is the shared backstop; `RPCMaxMessageSize` and the post-read size check that marked agents offline are **deleted** — no code path closes the connection or terminal channels because of message size any more. Browser terminal conns keep a separate 1 MiB `BrowserMaxMessageSize`; REST body caps use a REST-local `MaxSessionRequestBodySize`. Register ack advertises `max_message_bytes`. Relay-channel close made idempotent (the new snapshot test exposed a real double-close panic).
- **`services/agents`**: negotiates the limit from the register ack (512 KiB default for pre-#685 hubs); `prepareResponseFrame` bounds every RPC reply before writing — marshal → drop `prompt_context`/`prompt_type` → JSON-RPC `-32000` error — never sending a frame the hub would reject; marshal failures are no longer silently swallowed. `listSessions` (and `getDiagnostics`) are metadata-only; `getSession`/`createSession` keep the prompt fields. PTY buffer cap and `config.go` comment use the shared constants.
- **`services/issues-ui`**: `NotificationDropdown` fetches `prompt_context` per waiting session via new `fetchSession` / `useSessionPromptContext` (keyed on `idle_since`, only while the dropdown is open), with a "Loading prompt…" placeholder and graceful fallback.
- **docs**: runbook Mode C corrected — the trigger is the relay snapshot replay on hover/terminal-open, not persisted-state sync.

**Deploy note:** the relay fix is hub-side; deploying agent-hub alone stops the hover-triggered drops. The agentd half adds the negotiated limit, sender-side degrade, and metadata-only `listSessions`. Old agentd + new hub and new agentd + old hub both remain compatible (`max_message_bytes` is optional; agentd defaults to 512 KiB).

Fixes #685

## Test plan
- [x] Reproduction tests written first and confirmed failing for the right reason on `main` (`read limited at 1048577 bytes`; agent marked offline on 600 KiB text frame; constants invariant violated)
- [x] `shellcheck` verification passes
- [x] `go vet && go test ./...` green in `services/shared`, `services/agent-hub`, `services/agents`
- [x] `tsc -b` clean; vitest 43 files / 805 tests pass
- [x] New: `TestIntegration_MultiMiBListSessionsKeepsAgentOnline` (3 MiB `listSessions` passed through, agent online, pre-opened relay still delivers), `TestHandleAgentWebSocket_RegisterAdvertisesMaxMessageBytes`, `TestClientRegisterNegotiatesMaxMessageBytes`, `TestPrepareResponseFrame*`, `TestListSessions_WorstCasePayloadBounded` (200 sessions → 1.22 MB, < 4 MiB), `TestTerminalRelayCloseIsIdempotent`, `useSessionPromptContext.test.ts`
- [ ] Manual QA: deploy hub + agentd; hover/open a session with ≥1 MiB scrollback; host stays online and `last_seen` keeps advancing; notification dropdown still shows waiting prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)