### PR TITLE
fix(#691): close websocket connection when marking agent offline for liveness

### DIFF
--- a/services/agent-hub/internal/hub/hub.go
+++ b/services/agent-hub/internal/hub/hub.go
@@ -508,16 +508,24 @@ func (h *Hub) reaper(ctx context.Context) {
 		case <-ticker.C:
 			h.mu.Lock()
 			now := time.Now()
+			var staleConns []*websocket.Conn
 			for name, agent := range h.agents {
 				if agent.Status() == StatusOffline && now.Sub(agent.LastSeen()) > h.agentTTL {
 					slog.Info("reaping stale agent", "agent", name, "last_seen", agent.LastSeen())
 					if conn := agent.Conn(); conn != nil {
-						conn.Close(websocket.StatusGoingAway, "reaped: stale agent")
+						staleConns = append(staleConns, conn)
 					}
 					delete(h.agents, name)
 				}
 			}
 			h.mu.Unlock()
+
+			// Close connections outside the lock: Close can block for the
+			// duration of the close handshake (up to several seconds), and
+			// must not stall other hub map operations while reaping.
+			for _, conn := range staleConns {
+				conn.Close(websocket.StatusGoingAway, "reaped: stale agent")
+			}
 		}
 	}
 }

--- a/services/agent-hub/internal/hub/hub.go
+++ b/services/agent-hub/internal/hub/hub.go
@@ -210,6 +210,9 @@ func (h *Hub) markOfflineIfCurrent(name string, expected *ConnectedAgent) {
 
 	if ok && current == expected {
 		expected.SetStatus(StatusOffline)
+		if conn := expected.Conn(); conn != nil {
+			conn.Close(websocket.StatusGoingAway, "liveness check failed")
+		}
 		slog.Info("agent marked offline", "agent", name)
 	}
 }
@@ -508,6 +511,9 @@ func (h *Hub) reaper(ctx context.Context) {
 			for name, agent := range h.agents {
 				if agent.Status() == StatusOffline && now.Sub(agent.LastSeen()) > h.agentTTL {
 					slog.Info("reaping stale agent", "agent", name, "last_seen", agent.LastSeen())
+					if conn := agent.Conn(); conn != nil {
+						conn.Close(websocket.StatusGoingAway, "reaped: stale agent")
+					}
 					delete(h.agents, name)
 				}
 			}

--- a/services/agent-hub/internal/hub/hub_test.go
+++ b/services/agent-hub/internal/hub/hub_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -234,6 +235,222 @@ func TestHeartbeatTimeout(t *testing.T) {
 	if agent.Status() != StatusOffline {
 		t.Errorf("expected agent to be marked offline after heartbeat timeout, got %s", agent.Status())
 	}
+}
+
+// TestHeartbeatTimeoutClosesConnection covers issue #691: a heartbeat
+// timeout marks the agent offline via markOfflineIfCurrent, which must also
+// close the underlying websocket connection. Otherwise HandleAgentConnection's
+// read loop would stay alive and keep calling Touch() on the "offline" agent,
+// and the client-side connection would remain usable, preventing the agent
+// from ever reconnecting. This test asserts the fixed behavior: once the
+// agent is marked offline, the original connection is closed — a write from
+// the original client connection fails, and LastSeen no longer advances.
+func TestHeartbeatTimeoutClosesConnection(t *testing.T) {
+	h, url := startTestHubWithHeartbeat(t, 50*time.Millisecond, 50*time.Millisecond)
+
+	conn := connectRawAgent(t, url, "raw-silent-agent")
+	defer conn.CloseNow()
+
+	agent := waitForAgent(t, h, "raw-silent-agent")
+
+	if agent.Status() != StatusOnline {
+		t.Fatalf("expected agent to start online, got %s", agent.Status())
+	}
+
+	// Poll until the agent is marked offline by the heartbeat timeout. The
+	// client never reads or responds to the hub's heartbeat ping, so the
+	// heartbeat loop's timeout branch will fire and call markOfflineIfCurrent.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if agent.Status() == StatusOffline {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if agent.Status() != StatusOffline {
+		t.Fatalf("expected agent to be marked offline after heartbeat timeout, got %s", agent.Status())
+	}
+
+	lastSeenBeforeWrite := agent.LastSeen()
+
+	// The underlying websocket connection must have been closed when the
+	// agent was marked offline. Prove this by writing a message from the
+	// original client connection: either the write itself fails immediately
+	// (connection already closed locally), or the hub's read loop has
+	// exited and never processes the message, so LastSeen must not advance.
+	req, err := NewRequest("post-offline-1", "noop", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	writeErr := conn.Write(context.Background(), websocket.MessageText, data)
+
+	touchDeadline := time.Now().Add(1 * time.Second)
+	touched := false
+	for time.Now().Before(touchDeadline) {
+		if agent.LastSeen().After(lastSeenBeforeWrite) {
+			touched = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if touched {
+		t.Fatalf("expected hub's read loop to have exited after the agent went offline, but LastSeen advanced after a post-offline write")
+	}
+
+	if writeErr == nil {
+		// The local write may briefly succeed if it races the close
+		// handshake, but the connection must observe the close shortly
+		// after: poll with bounded per-attempt reads until Read reports an
+		// error (the expected outcome), or the deadline is reached.
+		readDeadline := time.Now().Add(1 * time.Second)
+		closed := false
+		for time.Now().Before(readDeadline) {
+			readCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			_, _, readErr := conn.Read(readCtx)
+			cancel()
+			if readErr != nil && !errors.Is(readErr, context.DeadlineExceeded) {
+				closed = true
+				break
+			}
+		}
+		if !closed {
+			t.Fatalf("expected connection to be closed after agent marked offline, but reads kept succeeding or timing out")
+		}
+	}
+
+	if agent.Status() != StatusOffline {
+		t.Fatalf("expected agent to remain marked offline, got %s", agent.Status())
+	}
+}
+
+// dialAndRegisterNoFatal dials the test server and registers under name,
+// without using t.Fatalf (safe to call from a background goroutine, unlike
+// t.Fatalf/FailNow which must only be called from the test's own goroutine).
+func dialAndRegisterNoFatal(url, name string) (*websocket.Conn, error) {
+	wsURL := "ws" + strings.TrimPrefix(url, "http")
+	conn, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial: %w", err)
+	}
+
+	regReq, err := NewRequest("reg-1", "register", &RegisterParams{
+		Name:     name,
+		Profiles: map[string]ProfileInfo{"default": {Description: "test", Repo: "https://github.com/test/repo"}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build register request: %w", err)
+	}
+	data, err := json.Marshal(regReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal register request: %w", err)
+	}
+	if err := conn.Write(context.Background(), websocket.MessageText, data); err != nil {
+		return nil, fmt.Errorf("write register: %w", err)
+	}
+	if _, _, err := conn.Read(context.Background()); err != nil {
+		return nil, fmt.Errorf("read register ack: %w", err)
+	}
+	return conn, nil
+}
+
+// connectReconnectingAgent dials and registers under name, then behaves like
+// connectSilentAgent (never responding to heartbeat pings) until its
+// connection is closed by the hub. At that point it redials and re-registers
+// under the same name, and from then on behaves like connectAgent (echoing
+// responses to every request, including heartbeat pings), simulating how a
+// real agentd process reconnects after being dropped.
+func connectReconnectingAgent(t *testing.T, url, name string) *websocket.Conn {
+	t.Helper()
+
+	conn, err := dialAndRegisterNoFatal(url, name)
+	if err != nil {
+		t.Fatalf("initial connect: %v", err)
+	}
+
+	go func() {
+		// Silent phase: consume messages without replying, so heartbeat
+		// pings time out and the hub closes this connection.
+		for {
+			if _, _, err := conn.Read(context.Background()); err != nil {
+				break
+			}
+		}
+
+		// Reconnect under the same name and answer normally from here on.
+		reconnected, err := dialAndRegisterNoFatal(url, name)
+		if err != nil {
+			t.Logf("reconnect failed: %v", err)
+			return
+		}
+		for {
+			_, data, err := reconnected.Read(context.Background())
+			if err != nil {
+				return
+			}
+			var req Request
+			if err := json.Unmarshal(data, &req); err != nil {
+				continue
+			}
+			result, _ := json.Marshal(map[string]string{"echo": req.Method})
+			resp := &Response{JSONRPC: "2.0", ID: req.ID, Result: result}
+			respData, err := json.Marshal(resp)
+			if err != nil {
+				continue
+			}
+			if err := reconnected.Write(context.Background(), websocket.MessageText, respData); err != nil {
+				return
+			}
+		}
+	}()
+
+	return conn
+}
+
+// TestHeartbeatTimeoutThenReconnectRestoresOnline covers the acceptance
+// criteria for issue #691: after a heartbeat timeout marks an agent offline
+// and closes its connection, the agent must be able to reconnect and be
+// restored to online status. Before the fix, the stale connection was never
+// closed, so a reconnect attempt under the same name would only replace the
+// map entry while the old read loop kept running against a "phantom" agent —
+// this test guards against that regressing.
+func TestHeartbeatTimeoutThenReconnectRestoresOnline(t *testing.T) {
+	h, url := startTestHubWithHeartbeat(t, 50*time.Millisecond, 50*time.Millisecond)
+
+	connectReconnectingAgent(t, url, "reconnecting-agent")
+
+	agent := waitForAgent(t, h, "reconnecting-agent")
+	if agent.Status() != StatusOnline {
+		t.Fatalf("expected agent to start online, got %s", agent.Status())
+	}
+
+	// Poll until the heartbeat timeout marks the agent offline.
+	offlineDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(offlineDeadline) {
+		if agent.Status() == StatusOffline {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if agent.Status() != StatusOffline {
+		t.Fatalf("expected agent to be marked offline after heartbeat timeout, got %s", agent.Status())
+	}
+
+	// Poll until the reconnect completes and the agent is restored online.
+	// Register() replaces the map entry, so re-fetch via h.Get rather than
+	// reusing the (now stale) agent pointer.
+	onlineDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(onlineDeadline) {
+		if current, ok := h.Get("reconnecting-agent"); ok && current.Status() == StatusOnline {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected agent to be restored online after reconnect")
 }
 
 // TestWSKeepaliveLoop_Disabled verifies that a zero keepalive interval does not


### PR DESCRIPTION
## Summary

- `markOfflineIfCurrent` (`services/agent-hub/internal/hub/hub.go`) now closes the agent's websocket connection (`websocket.StatusGoingAway, "liveness check failed"`) inside the existing `current == expected` guard, alongside setting status offline. This single change covers all three liveness paths that call it: `heartbeatLoop` (ping write failure and pong timeout), `wsKeepaliveLoop` (protocol-level ping failure), and `Call`'s RPC-failure demotion.
- The reaper now closes a stale agent's connection (`websocket.StatusGoingAway, "reaped: stale agent"`) before evicting it from the map, fixing the same deadlock for the sleep/wake + reaper scenario described in the ticket.
- Without this, `HandleAgentConnection`'s read loop stayed alive on a connection whose agent was marked offline, kept calling `Touch()`, and the websocket library auto-answered agentd's protocol pings — so agentd's own keepalive kept succeeding and it never reconnected. One transient heartbeat hiccup (or any laptop sleep/wake cycle) permanently demoted the agent until the TCP connection happened to drop.
- Grepped the repo for other callers of the exported `MarkOffline` — none in production code, only tests, so no other call sites needed the fix.

Fixes #691

## Test plan

- Reproduced the bug first with a test proving the connection stayed open and `Touch()` kept firing after an offline transition (this test is now inverted into `TestHeartbeatTimeoutClosesConnection`, asserting the connection is actually closed).
- Added `TestHeartbeatTimeoutThenReconnectRestoresOnline`, covering the acceptance criterion end-to-end: heartbeat timeout → offline → connection closed → agent reconnects/re-registers → hub reports it online again, with no manual intervention.
- `cd services/agent-hub && go build ./... && go vet ./...` — clean
- `gofmt -l internal/hub/hub.go internal/hub/hub_test.go` — clean (pre-existing gofmt issues in `internal/config/config_test.go`, `internal/proxy/terminal_test.go`, `internal/rest/server.go` are unrelated to this change and untouched by this PR)
- `go test ./internal/hub/... -v -count=1` — full package suite passes
- `go test ./internal/hub/... -count=5` — no flakiness across 5 runs
- `go test ./internal/hub/... -race -count=1` — no races detected

## Attack Surface / Invariants

This PR touches connection/reconnection lifecycle logic in agent-hub.

1. **Invariant protected**: an agent's `status` and its underlying connection's liveness must stay in sync — if status is `offline`, the connection must not still be readable/writable, and if a connection is still open and serving reads, the status must not be `offline`. Previously this invariant was violated: status could be `offline` while the connection stayed fully alive.
2. **What breaks if violated**: the hub and the real agentd process disagree about connection state indefinitely (the deadlock this ticket describes) — the UI reports the agent unreachable while it's actually healthy and connected, until something external (TCP drop, process restart) breaks the tie.
3. **New trust boundaries / external inputs**: none. No new external inputs are introduced; this only changes internal handling of existing liveness-failure and reaper code paths. The `Close()` calls follow the same pattern already used by `Stop()` and `Register()`'s replace-on-reconnect path, and are nil-guarded for the (test-only) case of agents registered with a nil connection.